### PR TITLE
Rework of the French translation

### DIFF
--- a/main_fr.ts
+++ b/main_fr.ts
@@ -1,31 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="fr_FR">
 <context>
     <name>AboutWindow</name>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="14" />
+        <location filename="../src/AboutWindow.cpp" line="182" />
         <source>About</source>
         <translation>À propos</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="71" />
+        <location filename="../src/AboutWindow.cpp" line="184"/>
+        <source> Agreement</source>
+        <translation> Accord</translation>
+    </message>
+    <message>
+        <location filename="../src/AboutWindow.cpp" line="187"/>
         <source>™ and © 2020-2024 Epilogue. &lt;br&gt;All rights reserved. </source>
         <translation>™ et © 2020-2024 Epilogue. &lt;br&gt;Tous droits réservés.</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="111" />
         <source>Copyright Notices</source>
         <translation>Mentions de copyright</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="112" />
         <source>Software License Agreement</source>
-        <translation>Accord de licence logiciel</translation>
+        <translation type="vanished">Accord de licence logiciel</translation>
+    </message>
+</context>
+<context>
+    <name>AppTour</name>
+    <message>
+        <location filename="../src/AppTour.cpp" line="64"/>
+        <source>Welcome to the App Tour</source>
+        <translation>Bienvenue au tour guidé de l'app</translation>
+    </message>
+    <message>
+        <location filename="../src/AppTour.cpp" line="65"/>
+        <source>This tour will guide you through the app&apos;s features.</source>
+        <translation>Ce tour guidé de l'application vous fera découvrir ses fonctions.</translation>
+    </message>
+    <message>
+        <location filename="../src/AppTour.cpp" line="67"/>
+        <source>Start</source>
+        <translation>Commencer</translation>
+    </message>
+</context>
+<context>
+    <name>AppTourInfo</name>
+    <message>
+        <location filename="../src/AppTour.cpp" line="114"/>
+        <source>Next</source>
+        <translation>Suivant</translation>
+    </message>
+    <message>
+        <location filename="../src/AppTour.cpp" line="115"/>
+        <source>Skip Tour</source>
+        <translation>Passer</translation>
     </message>
 </context>
 <context>
     <name>BetaLabel</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="118" />
+        <location filename="../src/UIComponents.cpp" line="150"/>
+        <location filename="../src/UIComponents.cpp" line="164"/>
         <source>beta</source>
         <translation>bêta</translation>
     </message>
@@ -33,27 +70,27 @@
 <context>
     <name>CartDetailsWidget</name>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="26" />
+        <location filename="../src/CartDetailsWidget.cpp" line="451"/>
         <source>Official cartridge</source>
         <translation>Cartouche officielle</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="28" />
+        <location filename="../src/CartDetailsWidget.cpp" line="452"/>
         <source>Unofficial cartridge</source>
         <translation>Cartouche non officielle</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="30" />
+        <location filename="../src/CartDetailsWidget.cpp" line="453"/>
         <source>Unrecognized cartridge</source>
         <translation>Cartouche non reconnue</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="32" />
+        <location filename="../src/CartDetailsWidget.cpp" line="454"/>
         <source>Read-only cartridge</source>
         <translation>Cartouche en lecture seule</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="34" />
+        <location filename="../src/CartDetailsWidget.cpp" line="455"/>
         <source>Rewritable cartridge</source>
         <translation>Cartouche réinscriptible</translation>
     </message>
@@ -61,12 +98,12 @@
 <context>
     <name>CartSearchPage</name>
     <message>
-        <location filename="../src/CartSearchPage.cpp" line="11" />
+        <location filename="../src/CartSearchPage.cpp" line="56"/>
         <source>Please insert a cartridge</source>
         <translation>Veuillez insérer une cartouche</translation>
     </message>
     <message>
-        <location filename="../src/CartSearchPage.cpp" line="20" />
+        <location filename="../src/CartSearchPage.cpp" line="54"/>
         <source>Make sure your cartridge is properly inserted and its pins are clean.
 Do not remove the cartridge while any operation is running.</source>
         <translation>Assurez-vous que votre cartouche est correctement insérée et que ses broches sont propres.
@@ -76,12 +113,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>CheatCodesScreen</name>
     <message>
-        <location filename="../src/CheatCodesScreen.h" line="36" />
+        <location filename="../src/CheatCodesScreen.cpp" line="99"/>
         <source>Cheat Codes</source>
         <translation>Codes de triche</translation>
     </message>
     <message>
-        <location filename="../src/CheatCodesScreen.h" line="38" />
+        <location filename="../src/CheatCodesScreen.cpp" line="101"/>
         <source>Enable predefined cheats or use cheats from the internet to transform how you play, from abilities and mechanics to audio effects. Make sure you have autosave disabled so that your cartridge's save isn't overwritten while you're running cheats.</source>
         <translation>Activez des codes prédéfinis pour tricher ou entrez des codes de triche venant du net pour transformer votre façon de jouer, allant d'une modification des capacités et mécanismes du jeu jusqu'à des changements sonores. Veuillez désactiver la sauvegarde automatique lorsque vous utilisez des codes de triche afin que la sauvegarde de votre cartouche ne soit pas écrasée en exécutant des codes.</translation>
     </message>
@@ -89,35 +126,142 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>ControlsWidget</name>
     <message>
-        <location filename="../src/ControlsWidget.cpp" line="59" />
+        <location filename="../src/ControlsWidget.cpp" line="548"/>
         <source>Player: </source>
         <translation>Joueur :</translation>
     </message>
     <message>
-        <location filename="../src/ControlsWidget.cpp" line="135" />
+        <location filename="../src/ControlsWidget.cpp" line="547"/>
         <source>Input: </source>
         <translation>Entrée :</translation>
     </message>
 </context>
 <context>
+    <name>CoreCardWidget</name>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="181"/>
+        <source>Load Custom Core</source>
+        <translation>Chargez un cœur personnalisé</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="182"/>
+        <source>Cores (*%1)</source>
+        <translation>Cœurs (*%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="244"/>
+        <source>Active</source>
+        <translation>Actif</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="245"/>
+        <source>Enable</source>
+        <translation>Activer</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="246"/>
+        <source>Browse</source>
+        <translation>Chercher</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="247"/>
+        <source>Learn More</source>
+        <translation>En savoir plus</translation>
+    </message>
+</context>
+<context>
+    <name>CoreDownloader</name>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="277"/>
+        <source>Failed to download core</source>
+        <translation>Le cœur n'a pas pu être téléchargé</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="284"/>
+        <source>Failed to open file for writing</source>
+        <translation>Le fichier n'a pas pu être ouvert pour l'écriture</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="294"/>
+        <source>Failed to open zip file</source>
+        <translation>Le fichier zip n'a pas pu être ouvert</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreCardWidget.cpp" line="336"/>
+        <source>Download Error</source>
+        <translation>Le téléchargement a échoué</translation>
+    </message>
+</context>
+<context>
+    <name>CoreFeaturesWidget</name>
+    <message>
+        <location filename="../src/CoreCapabilitiesWidget.cpp" line="127"/>
+        <source>Supported Features</source>
+        <translation>Fonctionnalités disponibles</translation>
+    </message>
+</context>
+<context>
+    <name>CoreSelectorScreen</name>
+    <message>
+        <location filename="../src/CoreSelectorScreen.cpp" line="75"/>
+        <location filename="../src/CoreSelectorScreen.cpp" line="216"/>
+        <source>Officially supported</source>
+        <translation>Officiellement supporté</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreSelectorScreen.cpp" line="75"/>
+        <location filename="../src/CoreSelectorScreen.cpp" line="216"/>
+        <source>Alternative Core</source>
+        <translation>Cœur alternatif</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreSelectorScreen.cpp" line="208"/>
+        <source>Select Core</source>
+        <translation>Choix du cœur</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreSelectorScreen.cpp" line="210"/>
+        <source>You can change the emulation core for your Operator device. Download a core online or provide your own, but remember: only some cores are fully supported by Epilogue ensure complete feature compatibility.</source>
+        <translation>Vous pouvez changer le cœur d'émulation pour votre appareil Operator. Vous pouvez télécharger un cœur en ligne ou utiliser le votre, mais attention : seuls certains cœurs sont pleinement supportés par Epilogue pour s'assurer d'une compatibilité totale des fonctionnalités.</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreSelectorScreen.cpp" line="212"/>
+        <source>Custom Core</source>
+        <translation>Cœur personnalisé</translation>
+    </message>
+    <message>
+        <location filename="../src/CoreSelectorScreen.cpp" line="213"/>
+        <source>Your own core</source>
+        <translation>Votre propre cœur</translation>
+    </message>
+</context>
+<context>
+    <name>CoreSystemsWidget</name>
+    <message>
+        <location filename="../src/CoreCapabilitiesWidget.cpp" line="105"/>
+        <source>Supported Systems</source>
+        <translation>Consoles supportées</translation>
+    </message>
+</context>
+<context>
     <name>CustomCheatCodesWidget</name>
     <message>
-        <location filename="../src/CustomCheatCodesWidget.cpp" line="9" />
+        <location filename="../src/CustomCheatCodesWidget.cpp" line="228"/>
         <source>Custom Cheats</source>
         <translation>Codes de triche personnalisés</translation>
     </message>
     <message>
-        <location filename="../src/CustomCheatCodesWidget.cpp" line="35" />
+        <location filename="../src/CustomCheatCodesWidget.cpp" line="235"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/CustomCheatCodesWidget.cpp" line="36" />
+        <location filename="../src/CustomCheatCodesWidget.cpp" line="236"/>
         <source>Code</source>
         <translation>Code</translation>
     </message>
     <message>
-        <location filename="../src/CustomCheatCodesWidget.cpp" line="31" />
+        <location filename="../src/CustomCheatCodesWidget.cpp" line="237"/>
         <source>Enabled</source>
         <translation>Activé</translation>
     </message>
@@ -125,7 +269,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>DatabaseCheatCodesWidget</name>
     <message>
-        <location filename="../src/DatabaseCheatCodesWidget.cpp" line="8" />
+        <location filename="../src/DatabaseCheatCodesWidget.cpp" line="37"/>
+        <source>Search cheats</source>
+        <translation>Chercher des codes</translation>
+    </message>
+    <message>
+        <location filename="../src/DatabaseCheatCodesWidget.cpp" line="104"/>
         <source> Default Cheats</source>
         <translation> - Codes prédéfinis</translation>
     </message>
@@ -133,12 +282,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>DeviceBase</name>
     <message>
-        <location filename="../src/DeviceBase.cpp" line="266" />
+        <location filename="../src/DeviceBase.cpp" line="270"/>
         <source>Save data integrity check failed!</source>
         <translation>La vérification de l'intégrité des données de sauvegarde a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceBase.cpp" line="267" />
+        <location filename="../src/DeviceBase.cpp" line="271"/>
         <source>The save data appears to be inconsistent between read cycles. Please clean the cartridge pins and try again.</source>
         <translation>Les données de sauvegarde semblent inconsistentes entre les différentes lectures. Veuillez nettoyer les broches de la cartouche et réessayer.</translation>
     </message>
@@ -146,82 +295,82 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>DeviceHardware</name>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="98" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="98"/>
         <source>Game Data Integrity Check Failed!</source>
         <translation>La vérification de l'intégrité des données du jeu a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="99" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="99"/>
         <source>Playback detected a discrepancy between the expected game data and the backed up data. Please clean the cartridge pins and try again to ensure accuracy.</source>
         <translation>Playback a détecté une différence entre les données du jeu attendues et les données copiées. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l'authenticité des données.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="133" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="132"/>
         <source>Empty File Was Provided!</source>
         <translation>Un fichier vide a été fourni !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="134" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="133"/>
         <source> It looks like the homebrew game you're trying to upload has been detected by Playback as having 0 bytes. Please verify that the data you're attempting to upload is accurate.</source>
         <translation> Il semble que le jeu homebrew que vous essayez de téléverser ait été détecté par Playback comme ayant 0 octet. Veuillez vérifier que les données que vous essayez de téléverser sont correctes.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="145" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="143"/>
         <source>Upload Homebrew Command Failed!</source>
         <translation>La commande de téléversement d'homebrew a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="146" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="144"/>
         <source>An error occurred while attempting to start the homebrew upload command. Please restart the application and reconnect the Operator device. If the problem continues, contact our Support team.</source>
         <translation>Une erreur s'est produite lors du lancement de la commande de téléversement d'homebrew. Veuillez redémarrer l'application et reconnecter l'appareil Operator. Si le problème persiste, contactez notre équipe d'assistance.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="175" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="173"/>
         <source>Homebrew Cartridge Erase Failed!</source>
         <translation>L'effacement des données de la cartouche homebrew a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="176" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="174"/>
         <source>Playback couldn't delete the contents of the homebrew cartridge. Please clean the cartridge pins and try again. If the issue persists, contact our Support team.</source>
         <translation>Playback n'a pas pu supprimer le contenu de la cartouche homebrew. Veuillez nettoyer les broches de la cartouche et réessayer. Si le problème persiste, contactez notre équipe d'assistance.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="196" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="193"/>
         <source>Homebrew Cartridge Data Integrity Check Failed!</source>
         <translation>La vérification de l'intégrité des données de la cartouche homebrew a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="197" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="194"/>
         <source>The cartridge was erased successfully, but the data written does not match the data read back. This issue might occur with some homebrew cartridges. Make sure the game is playable, either by testing on an original console or in the Playback app.</source>
         <translation>Les données de la cartouche ont été effacées, mais les données écrites ne correspondent pas aux données relues. Ce problème peut se produire avec certaines cartouches homebrew. Assurez-vous que le jeu est jouable, soit en le testant sur une console d'origine, soit dans l'application Playback.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="233" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="228"/>
         <source>Written game data integrity check failed</source>
         <translation>La vérification de l'intégrité des données du jeu écrit a échoué</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="233" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="228"/>
         <source>Read data does not match written data.</source>
         <translation>Les données lues ne correspondent pas aux données écrites.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="340" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="334"/>
         <source>Write save failed</source>
         <translation>L'écriture de la sauvegarde a échoué</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="340" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="334"/>
         <source>Failed to send write save command to device.</source>
         <translation>Échec de l'envoi de l'écriture de la sauvegarde à l'appareil.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="371" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="363"/>
         <source>Save Data Integrity Check Failed!</source>
         <translation>La vérification de l'intégrité des données de sauvegarde a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/DeviceHardwareOperations.cpp" line="372" />
+        <location filename="../src/DeviceHardwareOperations.cpp" line="364"/>
         <source>The save data written to the cartridge does not match the data read back. Please clean the cartridge pins and try again to ensure consistency.</source>
         <translation>Les données de sauvegarde écrites dans la cartouche ne correspondent pas aux données relues. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l'authenticité des données.</translation>
     </message>
@@ -229,12 +378,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>DeviceSettingsScreen</name>
     <message>
-        <location filename="../src/DeviceSettingsScreen.h" line="78" />
+        <location filename="../src/DeviceSettingsScreen.cpp" line="68"/>
         <source>LED Effects</source>
         <translation>Effets LED</translation>
     </message>
     <message>
-        <location filename="../src/DeviceSettingsScreen.h" line="79" />
+        <location filename="../src/DeviceSettingsScreen.cpp" line="69"/>
         <source>Choose one of the options below to set the status of your device’s LED light. Select ‘Static’ to keep the light on or ‘Dark’ to shut it off. Pulse and Strobe coming soon.</source>
         <translation>Choisissez l'une des options ci-dessous pour changer l'état de la lumière LED de votre appareil. Sélectionnez « Statique » pour que la lumière reste allumée ou « Sombre » pour l'éteindre. Les options « Pulsation » et « Stroboscopique » seront bientôt disponibles.</translation>
     </message>
@@ -242,15 +391,14 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>DeviceSharedMemory</name>
     <message>
-        <location filename="../src/DeviceSharedMemory.cpp" line="16" />
         <source>Shared Memory Error</source>
-        <translation>Erreur de mémoire partagée</translation>
+        <translation type="obsolete">Erreur de mémoire partagée</translation>
     </message>
 </context>
 <context>
     <name>DeviceSwitcherDropdown</name>
     <message>
-        <location filename="../src/DeviceSwitcherDropdown.h" line="78" />
+        <location filename="../src/DeviceSwitcherDropdown.cpp" line="147"/>
         <source>Expand your collection on epilogue.co</source>
         <translation>Agrandissez votre collection sur epilogue.co</translation>
     </message>
@@ -258,7 +406,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>DeviceSwitcherDropdownStoreItem</name>
     <message>
-        <location filename="../src/DeviceSwitcherDropdown.cpp" line="194" />
+        <location filename="../src/DeviceSwitcherDropdown.cpp" line="237"/>
         <source>View more</source>
         <translation>Voir plus</translation>
     </message>
@@ -266,22 +414,22 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>Emulator</name>
     <message>
-        <location filename="../src/Emulator.cpp" line="265" />
+        <location filename="../src/Emulator.cpp" line="261"/>
         <source>Failed to load game!</source>
         <translation>Échec du chargement du jeu !</translation>
     </message>
     <message>
-        <location filename="../src/Emulator.cpp" line="266" />
+        <location filename="../src/Emulator.cpp" line="262"/>
         <source>Unable to launch the game, please make sure that the cartridge is clean.</source>
         <translation>Le jeu n'a pas pu être démarré : assurez-vous que la cartouche est propre.</translation>
     </message>
     <message>
-        <location filename="../src/Emulator.cpp" line="272" />
+        <location filename="../src/Emulator.cpp" line="268"/>
         <source>Failed to load save data!</source>
         <translation>Échec du chargement des données de sauvegarde !</translation>
     </message>
     <message>
-        <location filename="../src/Emulator.cpp" line="272" />
+        <location filename="../src/Emulator.cpp" line="268"/>
         <source>The core failed to load the save data.</source>
         <translation>Le cœur n'a pas réussi à charger les données de sauvegarde.</translation>
     </message>
@@ -289,56 +437,96 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>EmulatorSettingsScreen</name>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="173" />
-        <location filename="../src/EmulatorSettingsScreen.h" line="189" />
-        <location filename="../src/EmulatorSettingsScreen.h" line="205" />
+        <location filename="../src/EmulatorSettingsScreen.h" line="137"/>
+        <location filename="../src/EmulatorSettingsScreen.h" line="152"/>
+        <location filename="../src/EmulatorSettingsScreen.h" line="167"/>
         <source>enabled</source>
         <translation>activé</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="174" />
-        <location filename="../src/EmulatorSettingsScreen.h" line="190" />
-        <location filename="../src/EmulatorSettingsScreen.h" line="206" />
+        <location filename="../src/EmulatorSettingsScreen.h" line="138"/>
+        <location filename="../src/EmulatorSettingsScreen.h" line="153"/>
+        <location filename="../src/EmulatorSettingsScreen.h" line="168"/>
         <source>disabled</source>
         <translation>désactivé</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="137" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="251"/>
         <source>Fast-forward speed multiplier (Re-enable)</source>
         <translation>Multiplicateur de vitesse de l'avance rapide (Réactivation)</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="139" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="260"/>
         <source>A fast-forward speed higher than 2x can cause unexpected bugs in combination with the 'Autosave to cartridge' feature. You will need to disable and enable it by clicking the fast-forward button.</source>
         <translation>Une avance rapide supérieure à 2x peut provoquer des bugs inattendus en combinaison avec la fonction « Sauvegarder automatiquement sur la cartouche ». Vous devrez désactiver et activer l'avance rapide en appuyant sur le bouton d'avance rapide en jouant.</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="164" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="252"/>
         <source>High Fidelity Mode</source>
         <translation>Mode haute fidélité</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="166" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="237"/>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="238"/>
+        <source>Input &amp; Auxiliary Devices</source>
+        <translation>Dispositifs d'entrée et auxiliaires</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="239"/>
+        <source>Core</source>
+        <translation>Cœur</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="244"/>
+        <source>Configure base hardware selection.</source>
+        <translation>Modifiez les paramètres de base de la console.</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="245"/>
+        <source>Configure controller and controller rumble settings.</source>
+        <translation>Modifiez les paramètres liés à la manette et aux vibrations.</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="246"/>
+        <source>Core settings</source>
+        <translation>Paramètres du cœur</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="265"/>
         <source>Enables high-fidelity mode, making audio and video run at rates close to what you would encounter on the original hardware. This will increase CPU usage, disable it if you notice low framerates.</source>
         <translation>Active le mode haute fidélité, permettant de faire fonctionner l'audio et la vidéo à des taux proches de ceux que vous rencontreriez sur la console d'origine. Cela augmentera l'utilisation du processeur, donc désactivez cette option si vous remarquez des taux d'images faibles.</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="182" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="300"/>
+        <source>Enabled</source>
+        <translation>Activé</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="301"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="253"/>
         <source>Gamepad rumble</source>
         <translation>Vibration de la manette</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="184" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="270"/>
         <source>Enable rumble support for games that support it, for more compatibility make sure you also enable Game Boy Player Rumble.</source>
         <translation>Activez les vibrations pour les jeux compatibles. Pour fonctionner avec le plus de jeux compatibles, assurez-vous d'activer également la Vibration Game Boy Player.</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="198" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="254"/>
         <source>In-game save verifications</source>
         <translation>Vérifications des sauvegardes en jeu</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="200" />
+        <location filename="../src/EmulatorSettingsScreen.cpp" line="273"/>
         <source>Enable in-game integrity checks for save data. This feature is still in beta and may not work with all games.</source>
         <translation>Activer les vérifications d'intégrité en jeu pour les données de sauvegarde. Cette fonctionnalité est encore en version bêta et peut ne pas fonctionner avec tous les jeux.</translation>
     </message>
@@ -346,12 +534,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>FirmwareUpdateDisclaimer</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="94" />
+        <location filename="../src/UIComponents.cpp" line="128"/>
         <source>Warning! Do not disconnect your device.</source>
         <translation>Attention ! Ne déconnectez pas votre appareil.</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="96" />
+        <location filename="../src/UIComponents.cpp" line="130"/>
         <source>Please DO NOT disconnect or turn off your device during the update process. The LED will turn off during the update. Interruption will lead to your device becoming unusable and void warranty. By agreeing to this message box you confirm your understanding of these instructions.</source>
         <translation>Veuillez NE PAS déconnecter ou éteindre votre appareil pendant la mise à jour. La LED s'éteindra pendant la mise à jour. Toute interruption rendra votre appareil inutilisable et annulera la garantie. En acceptant cette boîte de message, vous confirmez votre compréhension de ces instructions.</translation>
     </message>
@@ -359,19 +547,19 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
 <context>
     <name>FirmwareUpdateWindow</name>
     <message>
-        <location filename="../src/FirmwareUpdateWindow.h" line="21" />
+        <location filename="../src/FirmwareUpdateWindow.cpp" line="58"/>
         <source>Updating...</source>
         <translation>Mise à jour...</translation>
     </message>
     <message>
-        <location filename="../src/FirmwareUpdateWindow.h" line="22" />
+        <location filename="../src/FirmwareUpdateWindow.cpp" line="59"/>
         <source>This may take up to a minute,
 please do not disconnect the device.</source>
         <translation>Cela peut prendre une minute,
 veuillez ne pas déconnectez l'appareil.</translation>
     </message>
     <message>
-        <location filename="../src/FirmwareUpdateWindow.h" line="24" />
+        <location filename="../src/FirmwareUpdateWindow.cpp" line="60"/>
         <source>Not working?</source>
         <translation>Ça ne marche pas ?</translation>
     </message>
@@ -379,38 +567,35 @@ veuillez ne pas déconnectez l'appareil.</translation>
 <context>
     <name>InputBindingsScreen</name>
     <message>
-        <location filename="../src/InputBindingsScreen.cpp" line="17" />
-        <location filename="../src/InputBindingsScreen.h" line="69" />
+        <location filename="../src/InputBindingsScreen.cpp" line="172"/>
         <source>Rebind keys</source>
         <translation>Configurer les touches</translation>
     </message>
     <message>
-        <location filename="../src/InputBindingsScreen.cpp" line="29" />
+        <location filename="../src/InputBindingsScreen.cpp" line="178"/>
         <source>Need help?</source>
         <translation>Besoin d'aide ?</translation>
     </message>
     <message>
-        <location filename="../src/InputBindingsScreen.h" line="61" />
+        <location filename="../src/InputBindingsScreen.cpp" line="179"/>
         <source>Controls Settings</source>
         <translation>Configuration des touches</translation>
     </message>
     <message>
-        <location filename="../src/InputBindingsScreen.h" line="63" />
+        <location filename="../src/InputBindingsScreen.cpp" line="170"/>
         <source>The Playback software comes with pre-configured bindings for most gamepads. Try pressing buttons on your controller or keyboard to test them.</source>
         <translation>Le logiciel Playback contient des configurations par défaut pour la plupart des manettes de jeu. Essayez d'appuyer sur les boutons de votre manette ou sur les touches de votre clavier pour les tester.</translation>
     </message>
     <message>
-        <location filename="../src/InputBindingsScreen.h" line="66" />
         <source>No gamepads connected.</source>
-        <translation>Aucune manette n'est connectée.</translation>
+        <translation type="vanished">Aucune manette n'est connectée.</translation>
     </message>
     <message>
-        <location filename="../src/InputBindingsScreen.h" line="67" />
         <source>Select a gamepad</source>
-        <translation>Sélectionnez une manette</translation>
+        <translation type="vanished">Sélectionnez une manette</translation>
     </message>
     <message>
-        <location filename="../src/InputBindingsScreen.h" line="70" />
+        <location filename="../src/InputBindingsScreen.cpp" line="173"/>
         <source>Cancel rebind</source>
         <translation>Annuler le remappage</translation>
     </message>
@@ -418,12 +603,12 @@ veuillez ne pas déconnectez l'appareil.</translation>
 <context>
     <name>IntegrityAlertBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="42" />
+        <location filename="../src/UIComponents.cpp" line="59"/>
         <source>Integrity check failed!</source>
         <translation>Le contrôle d'intégrité a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="43" />
+        <location filename="../src/UIComponents.cpp" line="60"/>
         <source>We were unable to confirm the integrity of this cartridge, would you still like to proceed? The game might not play or save properly.
 
 You can try cleaning then re-inserting the cartridge into the device.
@@ -437,27 +622,27 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>LinuxDevicePermissionBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="83" />
+        <location filename="../src/UIComponents.cpp" line="113"/>
         <source>Permission denied. Unable to open device.</source>
         <translation>Permission refusée. Impossible d'ouvrir l'appareil.</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="85" />
+        <location filename="../src/UIComponents.cpp" line="115"/>
         <source>Please make sure you configure your Linux system to allow unprivileged access to serial ports.</source>
         <translation>Veuillez configurer votre système Linux afin d'autoriser l'accès non privilégié aux ports série.</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="86" />
+        <location filename="../src/UIComponents.cpp" line="116"/>
         <source>Follow this</source>
         <translation>Suivez ce</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="87" />
+        <location filename="../src/UIComponents.cpp" line="117"/>
         <source>tutorial</source>
         <translation>tutoriel</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="87" />
+        <location filename="../src/UIComponents.cpp" line="117"/>
         <source>to configure your Operator device.</source>
         <translation>pour configurer l'Operator.</translation>
     </message>
@@ -465,12 +650,12 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>ManageOperationFailBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="64" />
+        <location filename="../src/UIComponents.cpp" line="87"/>
         <source>Integrity check failed!</source>
         <translation>Le contrôle d'intégrité a échoué !</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="65" />
+        <location filename="../src/UIComponents.cpp" line="88"/>
         <source>Your Operator device did not manage to read your cartridge properly. Please make sure that the cartridge is clean and try again.</source>
         <translation>Votre appareil Operator n'a pas réussi à lire correctement votre cartouche. Assurez-vous que la cartouche est propre et réessayez.</translation>
     </message>
@@ -478,32 +663,34 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>ManagePage</name>
     <message>
-        <location filename="../src/ManagePage.cpp" line="9" />
+        <location filename="../src/ManagePage.cpp" line="223"/>
         <source>START</source>
         <translation>DÉMARRER</translation>
     </message>
     <message>
-        <location filename="../src/ManagePage.cpp" line="18" />
+        <location filename="../src/ManagePage.cpp" line="224"/>
         <source>Data Flow:</source>
         <translation>Flux de données :</translation>
     </message>
     <message>
-        <location filename="../src/ManagePage.cpp" line="96" />
+        <location filename="../src/ManagePage.cpp" line="99"/>
         <source>Unknown title</source>
         <translation>Titre inconnu</translation>
     </message>
     <message>
-        <location filename="../src/ManagePage.cpp" line="97" />
+        <location filename="../src/ManagePage.cpp" line="100"/>
         <source>[no checksum available]</source>
         <translation>[somme de contrôle indisponible]</translation>
     </message>
     <message>
-        <location filename="../src/ManagePage.h" line="57" />
+        <location filename="../src/ManagePage.cpp" line="102"/>
+        <location filename="../src/ManagePage.cpp" line="225"/>
         <source>Title</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../src/ManagePage.h" line="58" />
+        <location filename="../src/ManagePage.cpp" line="103"/>
+        <location filename="../src/ManagePage.cpp" line="226"/>
         <source>Game Data Checksum</source>
         <translation>Somme de contrôle des données de jeu</translation>
     </message>
@@ -511,23 +698,25 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>ManagePageOperation</name>
     <message>
-        <location filename="../src/ManagePageOperation.cpp" line="16" />
+        <location filename="../src/ManagePageOperation.cpp" line="345"/>
         <source>Warning, the file selected is too large!</source>
         <translation>Attention, le fichier sélectionné est trop volumineux !</translation>
     </message>
     <message>
-        <location filename="../src/ManagePageOperation.cpp" line="50" />
+        <location filename="../src/ManagePageOperation.cpp" line="50"/>
+        <location filename="../src/ManagePageOperation.cpp" line="346"/>
         <source>STOP</source>
         <translation>STOP</translation>
     </message>
     <message>
-        <location filename="../src/ManagePageOperation.cpp" line="185" />
-        <location filename="../src/ManagePageOperation.cpp" line="190" />
+        <location filename="../src/ManagePageOperation.cpp" line="211"/>
+        <location filename="../src/ManagePageOperation.cpp" line="216"/>
         <source>Game Data</source>
         <translation>Données du jeu</translation>
     </message>
     <message>
-        <location filename="../src/ManagePageOperation.cpp" line="311" />
+        <location filename="../src/ManagePageOperation.cpp" line="339"/>
+        <location filename="../src/ManagePageOperation.cpp" line="346"/>
         <source>START</source>
         <translation>DÉMARRER</translation>
     </message>
@@ -535,12 +724,12 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>MultipleInstancesBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="74" />
+        <location filename="../src/UIComponents.cpp" line="100"/>
         <source>Multiple instances detected!</source>
         <translation>Plusieurs instances détectées !</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="76" />
+        <location filename="../src/UIComponents.cpp" line="102"/>
         <source>It looks like there is another instance of the software running on this computer. Closing this instance.</source>
         <translation>Il semble qu'une autre instance du logiciel soit en cours d'exécution sur cet ordinateur. Veuillez fermer cette instance.</translation>
     </message>
@@ -548,50 +737,61 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>Navbar</name>
     <message>
-        <location filename="../src/Navbar.h" line="149" />
+        <location filename="../src/Navbar.cpp" line="207"/>
+        <location filename="../src/Navbar.cpp" line="242"/>
         <source>Press ESC to exit emulation</source>
         <translation>Appuyez sur ÉCHAP pour quitter l'émulation</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="150" />
+        <location filename="../src/Navbar.cpp" line="241"/>
         <source>Press TAB to exit mouse capture mode</source>
         <translation>Appuyez sur TAB pour quitter le mode de capture de la souris</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="151" />
+        <location filename="../src/Navbar.cpp" line="209"/>
         <source>Loading game...</source>
         <translation>Chargement du jeu...</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="152" />
+        <location filename="../src/Navbar.cpp" line="211"/>
         <source>Writing game...</source>
         <translation>Écriture des données de jeu...</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="153" />
+        <location filename="../src/Navbar.cpp" line="213"/>
         <source>Loading save...</source>
         <translation>Chargement de la sauvegarde...</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="154" />
+        <location filename="../src/Navbar.cpp" line="215"/>
         <source>Writing save...</source>
         <translation>Écriture de la sauvegarde...</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="155" />
+        <location filename="../src/Navbar.cpp" line="217"/>
         <source>Erasing data...</source>
         <translation>Effacement des données...</translation>
+    </message>
+    <message>
+        <location filename="../src/Navbar.cpp" line="248"/>
+        <source>PLAY</source>
+        <translation>JOUER</translation>
+    </message>
+    <message>
+        <location filename="../src/Navbar.cpp" line="249"/>
+        <source>DATA</source>
+        <translation>DONNÉES</translation>
     </message>
 </context>
 <context>
     <name>NavbarDeviceStatus</name>
     <message>
-        <location filename="../src/NavbarComponents.cpp" line="88" />
+        <location filename="../src/NavbarComponents.cpp" line="120"/>
         <source>Nightly</source>
         <translation>Nightly</translation>
     </message>
     <message>
-        <location filename="../src/NavbarComponents.cpp" line="100" />
+        <location filename="../src/NavbarComponents.cpp" line="118"/>
         <source>Debug</source>
         <translation>Débogage</translation>
     </message>
@@ -599,37 +799,42 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>NavbarLogoDropdown</name>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="34" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="122"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="37" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="123"/>
         <source>What's New</source>
         <translation>Nouveautés</translation>
     </message>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="38" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="124"/>
         <source>Support</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="41" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="125"/>
         <source>Send Feedback</source>
         <translation>Envoyer des retours</translation>
     </message>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="44" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="126"/>
         <source>Report a Bug</source>
         <translation>Signaler un bug</translation>
     </message>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="48" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="127"/>
+        <source>Vault</source>
+        <translation>Coffre-fort</translation>
+    </message>
+    <message>
+        <location filename="../src/NavbarLogoDropdown.cpp" line="128"/>
         <source>About</source>
         <translation>À propos de</translation>
     </message>
     <message>
-        <location filename="../src/NavbarLogoDropdown.cpp" line="49" />
+        <location filename="../src/NavbarLogoDropdown.cpp" line="129"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
@@ -637,40 +842,38 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>NavbarMenu</name>
     <message>
-        <location filename="../src/Navbar.h" line="24" />
         <source>PLAY</source>
-        <translation>JOUER</translation>
+        <translation type="vanished">JOUER</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="25" />
         <source>DATA</source>
-        <translation>DONNÉES</translation>
+        <translation type="vanished">DONNÉES</translation>
     </message>
 </context>
 <context>
     <name>NavbarSubmenu</name>
     <message>
-        <location filename="../src/Navbar.h" line="60" />
+        <location filename="../src/Navbar.cpp" line="424"/>
         <source>Backup Game</source>
         <translation>Télécharger le jeu</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="61" />
+        <location filename="../src/Navbar.cpp" line="425"/>
         <source>Upload Homebrew</source>
         <translation>Téléverser un homebrew</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="62" />
+        <location filename="../src/Navbar.cpp" line="426"/>
         <source>Backup Save</source>
         <translation>Télécharger la sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="63" />
+        <location filename="../src/Navbar.cpp" line="427"/>
         <source>Upload Save</source>
         <translation>Téléverser une sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/Navbar.h" line="64" />
+        <location filename="../src/Navbar.cpp" line="428"/>
         <source>Photo Gallery</source>
         <translation>Galerie photo</translation>
     </message>
@@ -678,32 +881,47 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
 <context>
     <name>PhotosPage</name>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="100" />
+        <location filename="../src/PhotosPage.cpp" line="351"/>
         <source>Scaling factor:</source>
         <translation>Taille :</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="168" />
+        <location filename="../src/PhotosPage.cpp" line="176"/>
         <source>Open Directory</source>
         <translation>Sélectionnez un dossier</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="186" />
+        <location filename="../src/PhotosPage.cpp" line="196"/>
         <source>Warning, permanent deletion</source>
         <translation>Attention, la suppression est définitive</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="187" />
+        <location filename="../src/PhotosPage.cpp" line="197"/>
         <source>This will permanently delete all the pictures on your Game Boy Camera. Are you sure?</source>
         <translation>Cela supprimera définitivement toutes les photos de votre Game Boy Camera. Êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="15" />
+        <location filename="../src/PhotosPage.cpp" line="315"/>
+        <source>Found %1 photos on your Game Boy Camera.</source>
+        <translation>%1 photos ont été trouvées sur votre Game Boy Camera.</translation>
+    </message>
+    <message>
+        <location filename="../src/PhotosPage.cpp" line="318"/>
+        <source>Found 1 photo on your Game Boy Camera.</source>
+        <translation>1 photo a été trouvée sur votre Game Boy Camera.</translation>
+    </message>
+    <message>
+        <location filename="../src/PhotosPage.cpp" line="322"/>
+        <source>Found no photos on your Game Boy Camera.</source>
+        <translation>Aucune photo n'a été trouvée sur votre Game Boy Camera.</translation>
+    </message>
+    <message>
+        <location filename="../src/PhotosPage.cpp" line="350"/>
         <source>Photo Gallery</source>
         <translation>Galerie photo</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.h" line="76" />
+        <location filename="../src/PhotosPage.cpp" line="344"/>
         <source>Transfer your pics from your Game Boy Camera to your PC in just two clicks. The images are stored as PNGs of 128x112 pixels. You can scale this using the scaling function.
 
 If you'd like to easily remove all the pictures from your camera, without having to manually delete them one by one in the camera software, you can use the delete button below.</source>
@@ -712,12 +930,12 @@ If you'd like to easily remove all the pictures from your camera, without having
 Si vous souhaitez supprimer facilement toutes les images de votre caméra sans avoir à les supprimer manuellement une par une dans le logiciel de la caméra, vous pouvez utiliser le bouton de suppression ci-dessous.</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="13" />
+        <location filename="../src/PhotosPage.cpp" line="348"/>
         <source>SAVE ALL</source>
         <translation>TOUT SAUVEGARDER</translation>
     </message>
     <message>
-        <location filename="../src/PhotosPage.cpp" line="14" />
+        <location filename="../src/PhotosPage.cpp" line="349"/>
         <source>DELETE ALL</source>
         <translation>TOUT SUPPRIMER</translation>
     </message>
@@ -729,12 +947,11 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
         <translation type="obsolete">Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="116" />
         <source>Preferred Language (requires restart)</source>
-        <translation>Langue préférée (nécessite un redémarrage)</translation>
+        <translation type="obsolete">Langue préférée (nécessite un redémarrage)</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="117" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="105"/>
         <source>Allows you to change the language in which the Playback software is presented. It requires an application restart in order to update the language accross the entire application.</source>
         <translation>Permet de changer la langue dans laquelle le logiciel Playback est affiché. Un redémarrage de l'application est nécessaire pour mettre à jour la langue dans l'ensemble de l'application.</translation>
     </message>
@@ -743,124 +960,113 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
         <translation type="obsolete">Sauvegarder automatiquement sur la cartouche (bêta)</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="151" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="109"/>
         <source>Once you save in-game, or the game modifies the save internally, your Operator device will automatically write the save to the cartridge. This feature is still in development.</source>
         <translation>Une fois que vous avez sauvegardé en jeu, ou que le jeu a modifié la sauvegarde en interne, votre appareil Operator écrira automatiquement la sauvegarde sur la cartouche. Cette fonction est encore en cours de développement.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="154" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="161" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="170" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="178" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="187" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="195" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="204" />
         <source>Enabled</source>
-        <translation>Activé</translation>
+        <translation type="obsolete">Activé</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="154" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="161" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="170" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="178" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="187" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="195" />
-        <location filename="../src/PlaybackSettingsScreen.h" line="204" />
         <source>Disabled</source>
-        <translation>Désactivé</translation>
+        <translation type="obsolete">Désactivé</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="159" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="93"/>
         <source>FPS Counter</source>
         <translation>Compteur d'IPS</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="160" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="113"/>
         <source>Displays the current frames per second (FPS) of the game being played.</source>
         <translation>Affiche le nombre d'images par seconde (IPS) du jeu en cours.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="138" />
         <source>Preferred emulator core</source>
-        <translation>Cœur d'émulateur préféré</translation>
+        <translation type="obsolete">Cœur d'émulateur préféré</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="139" />
         <source>Allows you to select the preferred emulation core for running games. Different cores may offer varying levels of accuracy, performance, or compatibility with specific games. Choose the core that best suits your needs and the game you're playing.</source>
-        <translation>Permet de sélectionner le cœur d'émulation préféré pour l'exécution des jeux. Les différents cœurs peuvent offrir différents niveaux de précision, de performance ou de compatibilité avec des jeux spécifiques. Choisissez le cœur correspondant au mieux à vos besoins et au jeu auquel vous jouez.</translation>
+        <translation type="obsolete">Permet de sélectionner le cœur d'émulation préféré pour l'exécution des jeux. Les différents cœurs peuvent offrir différents niveaux de précision, de performance ou de compatibilité avec des jeux spécifiques. Choisissez le cœur correspondant au mieux à vos besoins et au jeu auquel vous jouez.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="150" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="92"/>
         <source>Autosave to cartridge</source>
         <translation>Sauvegarder automatiquement sur la cartouche</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="166" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="94"/>
         <source>RTC data in save file</source>
         <translation>Données HTR dans le fichier de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="167" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="115"/>
         <source>When enabled and supported by the game, Playback adds real-time clock (RTC) data to the save file. This ensures accurate preservation of time-based events. Note that this will increase the file size and might make it incompatible with other software.</source>
         <translation>Lorsqu'activé et pris en charge par le jeu, Playback ajoute les données de l'horloge temps réel (HTR) au fichier de sauvegarde. Cela permet de conserver fidèlement les événements liés au temps. Notez que cela augmente la taille du fichier et peut le rendre incompatible avec d'autres logiciels.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="175" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="95"/>
         <source>Verify Save After Writing Process</source>
         <translation>Vérifier la sauvegarde après l'écriture</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="176" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="91"/>
+        <source>Preferred Language</source>
+        <translation>Langue préférée</translation>
+    </message>
+    <message>
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="119"/>
         <source>Activating this setting prompts Playback to check that the save file remains uncorrupted after being written to the cartridge. It ensures your game progress has been safely stored.</source>
         <translation>Activer ce paramètre force Playback à vérifier que le fichier de sauvegarde n'a pas été corrompu après avoir été écrit sur la cartouche. Cela permet de s'assurer que les données du jeu ont été sauvegardées en toute sécurité.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="183" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="96"/>
         <source>Verify Save is Read Properly</source>
         <translation>Vérifier que la sauvegarde est lue correctement</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="184" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="122"/>
         <source>When this setting is enabled, Playback reads the save file from the cartridge multiple times and reviews any discrepancies to prevent data corruption.</source>
         <translation>Lorsque ce paramètre est activé, l'application lit plusieurs fois la sauvegarde de la cartouche et examine toute anomalie afin d'éviter la corruption des données.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="192" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="97"/>
         <source>Verify Homebrew File Integrity</source>
         <translation>Vérifier l'intégrité des données du fichier homebrew</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="193" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="125"/>
         <source>This setting enables Playback to confirm the integrity of a homebrew game after transferring it to the cartridge, making sure there are no issues affecting your work.</source>
         <translation>Ce paramètre force Playback à confirmer l'intégrité d'un jeu homebrew après l'avoir transféré sur la cartouche, afin de s'assurer qu'aucun problème n'affecte votre travail.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="200" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="98"/>
         <source>Enable verbose debug logs (requires restart)</source>
         <translation>Activer les journaux de débogage descriptifs (nécessite un redémarrage)</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.h" line="201" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="128"/>
         <source>When enabled, the Playback software will output more detailed logs to help diagnose issues. This setting is useful for troubleshooting and should be disabled when not needed.</source>
         <translation>Lorsque cette option est activée, Playback produit des journaux plus détaillés pour aider à diagnostiquer les problèmes. Ce paramètre est utile pour le dépannage et doit être désactivé lorsqu'il n'est pas nécessaire.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.cpp" line="49" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="78"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.cpp" line="49" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="84"/>
         <source>Customize general settings to offer a personalized experience.</source>
         <translation>Changez les paramètres globaux pour modifier votre expérience.</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.cpp" line="52" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="79"/>
         <source>Data</source>
         <translation>Données</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.cpp" line="52" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="86"/>
         <source>Configure how transfers are handled in the Data section of Playback.</source>
         <translation>Modifiez le traitement des transferts dans la section Données de Playback.</translation>
     </message>
@@ -868,20 +1074,29 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
 <context>
     <name>PlaybackSettingsScreenOption</name>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.cpp" line="196" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="185"/>
         <source>Open Log Directory</source>
         <translation>Ouvrir le dossier des journaux</translation>
     </message>
     <message>
-        <location filename="../src/PlaybackSettingsScreen.cpp" line="202" />
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="191"/>
+        <source>Enabled</source>
+        <translation>Activé</translation>
+    </message>
+    <message>
+        <location filename="../src/PlaybackSettingsScreen.cpp" line="192"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
         <source>Open Cores Directory</source>
-        <translation>Ouvrir le dossier des cœurs</translation>
+        <translation type="obsolete">Ouvrir le dossier des cœurs</translation>
     </message>
 </context>
 <context>
     <name>ProgressGridWidget</name>
     <message>
-        <location filename="../src/ProgressGridWidget.cpp" line="17" />
+        <location filename="../src/ProgressGridWidget.cpp" line="148"/>
         <source>Data Grid:</source>
         <translation>Grille de données :</translation>
     </message>
@@ -889,77 +1104,77 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="94" />
+        <location filename="../src/AboutWindow.cpp" line="178"/>
         <source>Copyright Notices</source>
         <translation>Mentions de copyright</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="95" />
+        <location filename="../src/AboutWindow.cpp" line="179"/>
         <source>Software License</source>
         <translation>Licence logiciel</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="154" />
+        <location filename="../src/AboutWindow.cpp" line="152"/>
         <source>Software</source>
         <translation>Logiciel</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="155" />
+        <location filename="../src/AboutWindow.cpp" line="153"/>
         <source>Device Version</source>
         <translation>Version de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="156" />
+        <location filename="../src/AboutWindow.cpp" line="154"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/AboutWindow.cpp" line="157" />
+        <location filename="../src/AboutWindow.cpp" line="155"/>
         <source>Core Version</source>
         <translation>Version du cœur</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="9" />
+        <location filename="../src/CartDetailsWidget.cpp" line="286"/>
         <source>Unknown title</source>
         <translation>Titre inconnu</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="11" />
+        <location filename="../src/CartDetailsWidget.cpp" line="292"/>
         <source>The description of this cartridge can’t be displayed since it’s not in our database. You can use the link below to open a ticket and we’ll add the game info to the database. Please feel free to contact us even if it’s a homebrew game you made if you’d like to have your artwork displayed here.</source>
         <translation>La description de cette cartouche ne peut être affichée car elle n'est pas dans notre base de données. Vous pouvez utiliser le lien ci-dessous pour ouvrir un ticket et nous ajouterons les informations du jeu dans la base de données. N'hésitez pas à nous contacter même s'il s'agit d'un jeu homebrew que vous avez créé si vous souhaitez que votre jaquette soit affichée ici.</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="18" />
+        <location filename="../src/CartDetailsWidget.cpp" line="299"/>
         <source>Submit cartridge information</source>
         <translation>Envoyer des informations sur la cartouche</translation>
     </message>
     <message>
-        <location filename="../src/CartDetailsWidget.cpp" line="19" />
+        <location filename="../src/CartDetailsWidget.cpp" line="314"/>
         <source>Unknown developer</source>
         <translation>Développeur inconnu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceSettingsScreen.cpp" line="4" />
+        <location filename="../src/DeviceSettingsScreen.cpp" line="4"/>
         <source>Static</source>
         <translation>Statique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceSettingsScreen.cpp" line="5" />
+        <location filename="../src/DeviceSettingsScreen.cpp" line="5"/>
         <source>Dark</source>
         <translation>Sombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceSettingsScreen.cpp" line="7" />
+        <location filename="../src/DeviceSettingsScreen.cpp" line="6"/>
         <source>Pulse</source>
         <translation>Pulsation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceSettingsScreen.cpp" line="8" />
+        <location filename="../src/DeviceSettingsScreen.cpp" line="7"/>
         <source>Strobe</source>
         <translation>Stroboscopique</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.h" line="48" />
+        <location filename="../src/ViewRouter.cpp" line="111"/>
         <source>Archive your game data securely on your computer, making a digital equivalent of your game collection. Game files are compatible with your chosen emulator.
 
 Tip: Our app runs a Data Integrity Test to make sure that you are getting an accurate reproduction of the cartridge’s content.</source>
@@ -968,7 +1183,7 @@ Tip: Our app runs a Data Integrity Test to make sure that you are getting an acc
 Astuce : Notre application effectue une vérification de l'intégrité des données pour s'assurer que vous obtenez une reproduction exacte du contenu de la cartouche.</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.h" line="54" />
+        <location filename="../src/ViewRouter.cpp" line="119"/>
         <source>Overwrite the game data on your cartridge with a different file. Make sure the game file you’re writing is valid by testing it in an external emulator first.
 
 Tip: Transfer your homebrew game to a cartridge and play it on original hardware.</source>
@@ -977,7 +1192,7 @@ Tip: Transfer your homebrew game to a cartridge and play it on original hardware
 Astuce : transférez votre jeu homebrew sur une cartouche et jouez-y sur la console d'origine.</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.h" line="58" />
+        <location filename="../src/ViewRouter.cpp" line="125"/>
         <source>Transfer a duplicate of your save data from the cartridge to your computer. You can then back up your save file or edit it with an external program.
 
 Tip: Transfer your save to the computer, replace the battery and transfer it back to the cartridge safely.</source>
@@ -986,7 +1201,7 @@ Tip: Transfer your save to the computer, replace the battery and transfer it bac
 Astuce : transférez votre sauvegarde sur l'ordinateur, remplacez la batterie et transférez-la à nouveau sur la cartouche en toute sécurité.</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.h" line="64" />
+        <location filename="../src/ViewRouter.cpp" line="134"/>
         <source>Transfer a duplicate of your save data from your computer to the cartridge and pick the game up right where you left off.
 
 Tip: Use external programs to trigger in-game events or customize gameplay.</source>
@@ -995,17 +1210,17 @@ Tip: Use external programs to trigger in-game events or customize gameplay.</sou
 Astuce : utilisez des programmes externes pour déclencher des événements dans le jeu ou en modifier le gameplay.</translation>
     </message>
     <message>
-        <location filename="../src/ErrorMessages.h" line="26" />
+        <location filename="../src/ErrorMessages.h" line="26"/>
         <source>Follow this</source>
         <translation>Suivez ce</translation>
     </message>
     <message>
-        <location filename="../src/ErrorMessages.h" line="30" />
+        <location filename="../src/ErrorMessages.h" line="30"/>
         <source>tutorial</source>
         <translation>tutoriel</translation>
     </message>
     <message>
-        <location filename="../src/ErrorMessages.h" line="30" />
+        <location filename="../src/ErrorMessages.h" line="30"/>
         <source>for cleaning your cartridge pins.</source>
         <translation>pour nettoyer les broches de votre cartouche.</translation>
     </message>
@@ -1013,12 +1228,12 @@ Astuce : utilisez des programmes externes pour déclencher des événements dans
 <context>
     <name>QuitAlertBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="26" />
+        <location filename="../src/UIComponents.cpp" line="37"/>
         <source>You are about to quit.</source>
         <translation>Vous êtes sur le point de quitter.</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="27" />
+        <location filename="../src/UIComponents.cpp" line="38"/>
         <source>Are you sure you want to exit?</source>
         <translation>Êtes-vous sûr de vouloir quitter ?</translation>
     </message>
@@ -1026,12 +1241,12 @@ Astuce : utilisez des programmes externes pour déclencher des événements dans
 <context>
     <name>SaveMismatchAlertBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="52" />
+        <location filename="../src/UIComponents.cpp" line="72"/>
         <source>Mismatched save size</source>
         <translation>Taille de la sauvegarde inadéquate</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="53" />
+        <location filename="../src/UIComponents.cpp" line="73"/>
         <source>The emulator core is currently reporting a save size which is different than what we detected on the cartridge.
 
 You can read more about this issue here. Backups of the original save on the cartridge is made to the vault, however proceeding may create unusable saves.
@@ -1049,19 +1264,19 @@ Souhaitez-vous tout de même continuer ?
 <context>
     <name>SearchWindow</name>
     <message>
-        <location filename="../src/SearchWindow.h" line="21" />
+        <location filename="../src/SearchWindow.cpp" line="52"/>
         <source>Searching...</source>
         <translation>Recherche...</translation>
     </message>
     <message>
-        <location filename="../src/SearchWindow.h" line="24" />
+        <location filename="../src/SearchWindow.cpp" line="53"/>
         <source>Looking for your Operator device.
 Please make sure it's connected.</source>
         <translation>Recherche de l'appareil Operator.
 Assurez-vous qu'il est connecté.</translation>
     </message>
     <message>
-        <location filename="../src/SearchWindow.h" line="28" />
+        <location filename="../src/SearchWindow.cpp" line="55"/>
         <source>Not working?</source>
         <translation>Ça ne marche pas ?</translation>
     </message>
@@ -1069,55 +1284,66 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>SettingsScreenOption</name>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="130" />
         <source>System</source>
-        <translation>Système</translation>
+        <translation type="obsolete">Système</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="130" />
         <source>Configure base hardware selection.</source>
-        <translation>Modifiez les paramètres de base de la console.</translation>
+        <translation type="obsolete">Modifiez les paramètres de base de la console.</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="131" />
         <source>Input &amp; Auxiliary Devices</source>
-        <translation>Dispositifs d'entrée et auxiliaires</translation>
+        <translation type="obsolete">Dispositifs d'entrée et auxiliaires</translation>
     </message>
     <message>
-        <location filename="../src/EmulatorSettingsScreen.h" line="132" />
         <source>Configure controller and controller rumble settings.</source>
-        <translation>Modifiez les paramètres liés à la manette et aux vibrations.</translation>
+        <translation type="obsolete">Modifiez les paramètres liés à la manette et aux vibrations.</translation>
     </message>
 </context>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../src/SettingsWindow.cpp" line="21" />
+        <location filename="../src/SettingsWindow.cpp" line="246"/>
+        <source>Core Load Failed</source>
+        <translation>Le chargement du cœur a échoué</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow.cpp" line="246"/>
+        <source>Failed to load core. Please load a valid core.</source>
+        <translation>Le cœur n'a pas pu être chargé. Veuillez charger un cœur valide.</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow.cpp" line="276"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/SettingsWindow.h" line="71" />
+        <location filename="../src/SettingsWindow.cpp" line="278"/>
+        <source>Core Selector</source>
+        <translation>Choix du cœur</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow.cpp" line="279"/>
         <source>Emulator Settings</source>
         <translation>Paramètres de l'émulateur</translation>
     </message>
     <message>
-        <location filename="../src/SettingsWindow.h" line="74" />
+        <location filename="../src/SettingsWindow.cpp" line="280"/>
         <source>Device Settings</source>
         <translation>Paramètres de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/SettingsWindow.h" line="77" />
+        <location filename="../src/SettingsWindow.cpp" line="281"/>
         <source>Controls Settings</source>
         <translation>Paramètres des touches</translation>
     </message>
     <message>
-        <location filename="../src/SettingsWindow.h" line="79" />
+        <location filename="../src/SettingsWindow.cpp" line="282"/>
         <source>Cheat Codes</source>
         <translation>Codes de triche</translation>
     </message>
     <message>
-        <location filename="../src/SettingsWindow.h" line="82" />
+        <location filename="../src/SettingsWindow.cpp" line="277"/>
         <source>Playback Settings</source>
         <translation>Paramètres de Playback</translation>
     </message>
@@ -1125,12 +1351,12 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>SettingsWindowScreenSaveButton</name>
     <message>
-        <location filename="../src/SettingsWindowUIComponents.cpp" line="30" />
+        <location filename="../src/SettingsWindowUIComponents.cpp" line="50"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/SettingsWindowUIComponents.cpp" line="31" />
+        <location filename="../src/SettingsWindowUIComponents.cpp" line="51"/>
         <source>Restore defaults</source>
         <translation>Réinitialiser options</translation>
     </message>
@@ -1138,13 +1364,15 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>StartControllerButton</name>
     <message>
-        <location filename="../src/StartControllerWidget.cpp" line="138" />
+        <location filename="../src/StartControllerWidget.cpp" line="159"/>
+        <location filename="../src/StartControllerWidget.cpp" line="170"/>
         <source>STOP</source>
         <translation>STOP</translation>
     </message>
     <message>
-        <location filename="../src/StartControllerWidget.cpp" line="138" />
-        <location filename="../src/StartControllerWidget.cpp" line="145" />
+        <location filename="../src/StartControllerWidget.cpp" line="159"/>
+        <location filename="../src/StartControllerWidget.cpp" line="164"/>
+        <location filename="../src/StartControllerWidget.cpp" line="170"/>
         <source>START</source>
         <translation>DÉMARRER</translation>
     </message>
@@ -1152,17 +1380,16 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>StartControllerWidget</name>
     <message>
-        <location filename="../src/StartControllerWidget.cpp" line="8" />
         <source>START</source>
-        <translation>DÉMARRER</translation>
+        <translation type="vanished">DÉMARRER</translation>
     </message>
     <message>
-        <location filename="../src/StartControllerWidget.cpp" line="9" />
+        <location filename="../src/StartControllerWidget.cpp" line="57"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/StartControllerWidget.cpp" line="12" />
+        <location filename="../src/StartControllerWidget.cpp" line="59"/>
         <source>Access the Vault for this game. The vault contains auto-saves created while playing the game.</source>
         <translation>Accédez au coffre-fort de ce jeu. Le coffre-fort contient les sauvegardes automatiques créées en jouant au jeu avec Playback.</translation>
     </message>
@@ -1170,12 +1397,12 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>UnsavedQuitAlertBox</name>
     <message>
-        <location filename="../src/UIComponents.cpp" line="34" />
+        <location filename="../src/UIComponents.cpp" line="48"/>
         <source>You are about to quit.</source>
         <translation>Vous êtes sur le point de quitter.</translation>
     </message>
     <message>
-        <location filename="../src/UIComponents.cpp" line="35" />
+        <location filename="../src/UIComponents.cpp" line="49"/>
         <source>Do you want to overwrite the current save to your cartridge?
 </source>
         <translation>Voulez-vous écraser la sauvegarde actuelle dans votre cartouche ?
@@ -1185,22 +1412,22 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>ViewRouter</name>
     <message>
-        <location filename="../src/ViewRouter.cpp" line="11" />
+        <location filename="../src/ViewRouter.cpp" line="115"/>
         <source>Backup Game</source>
         <translation>Télécharger le jeu</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.cpp" line="13" />
+        <location filename="../src/ViewRouter.cpp" line="122"/>
         <source>Upload Homebrew</source>
         <translation>Téléverser un homebrew</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.cpp" line="15" />
+        <location filename="../src/ViewRouter.cpp" line="130"/>
         <source>Backup Save</source>
         <translation>Télécharger la sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/ViewRouter.cpp" line="17" />
+        <location filename="../src/ViewRouter.cpp" line="137"/>
         <source>Upload Save</source>
         <translation>Téléverser une sauvegarde</translation>
     </message>
@@ -1208,24 +1435,114 @@ Assurez-vous qu'il est connecté.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/Window.cpp" line="128" />
+        <location filename="../src/Window.cpp" line="138"/>
+        <location filename="../src/Window.cpp" line="368"/>
         <source>A new app update is available</source>
         <translation>Une nouvelle mise à jour de l'application est disponible</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="128" />
+        <location filename="../src/Window.cpp" line="138"/>
+        <location filename="../src/Window.cpp" line="368"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="144" />
+        <location filename="../src/Window.cpp" line="159"/>
+        <location filename="../src/Window.cpp" line="366"/>
         <source>A new device update is available</source>
         <translation>Une nouvelle mise à jour de l'appareil est disponible</translation>
     </message>
     <message>
-        <location filename="../src/Window.cpp" line="144" />
+        <location filename="../src/Window.cpp" line="159"/>
+        <location filename="../src/Window.cpp" line="366"/>
         <source>Start</source>
         <translation>Démarrer</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="393"/>
+        <source>Control Hub</source>
+        <translation>Centre de contrôle</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="394"/>
+        <source>Navigate between game dumping, library management, and hardware diagnostics</source>
+        <translation>Naviguez entre la copie de jeux, la gestion de la bibliothèque et les diagnostics du matériel</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="401"/>
+        <source>Authentic Play Mode</source>
+        <translation>Mode de jeu authentique</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="402"/>
+        <source>Experience original console behavior with cycle-accurate emulation settings</source>
+        <translation>Vivez le comportement de la console d'origine avec des paramètres d'émulation aux cycles fidèles</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="409"/>
+        <source>Preservation Studio</source>
+        <translation>Studio de préservation</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="410"/>
+        <source>Configure ROM dumping parameters and cartridge maintenance protocols</source>
+        <translation>Ajustez les paramètres pour la copie de ROMs et les protocoles de maintenance des cartouches</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="417"/>
+        <source>Save Vault</source>
+        <translation>Coffre-fort des sauvegardes</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="418"/>
+        <source>Bank and manage battery-backed saves with checksum verification</source>
+        <translation>Conservez et gérez les sauvegardes des jeux à batterie avec une vérification de la somme de contrôle</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="425"/>
+        <source>Multi-System Interface</source>
+        <translation>Interface multi-consoles</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="426"/>
+        <source>Switch between supported retro platforms: GB/C/A, SNES and N64</source>
+        <translation>Alternez entre les différentes plateformes rétros supportées : GB/C/A, SNES et N64</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="433"/>
+        <source>Cartridge Diagnostics</source>
+        <translation>Diagnostics de la cartouche</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="434"/>
+        <source>View ROM hashes, save battery status, and cartridge preservation alerts</source>
+        <translation>Consultez les sommes de la ROM, le statut de la pile de sauvegarde, et les alertes de préservation de la cartouche</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="441"/>
+        <source>Data Hub</source>
+        <translation>Centre des données</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="442"/>
+        <source>Manage game data and create save backups compatible with original hardware and modern emulators</source>
+        <translation>Gérez les données de jeu et créez des copies de vos sauvegardes compatibles avec les consoles originales et les émulateurs modernes</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="449"/>
+        <source>Backup Save</source>
+        <translation>Copier la sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="450"/>
+        <location filename="../src/Window.cpp" line="458"/>
+        <source>Create save backups compatible with original hardware and modern emulators</source>
+        <translation>Créez des copies de vos sauvegardes compatibles avec les consoles originales et les émulateurs modernes</translation>
+    </message>
+    <message>
+        <location filename="../src/Window.cpp" line="457"/>
+        <source>Save Archiver</source>
+        <translation>Archiveur de sauvegardes</translation>
     </message>
 </context>
 </TS>

--- a/main_fr.ts
+++ b/main_fr.ts
@@ -32,12 +32,12 @@
     <message>
         <location filename="../src/AppTour.cpp" line="64"/>
         <source>Welcome to the App Tour</source>
-        <translation>Bienvenue au tour guidé de l'app</translation>
+        <translation>Bienvenue au tour guidé de l&apos;app</translation>
     </message>
     <message>
         <location filename="../src/AppTour.cpp" line="65"/>
         <source>This tour will guide you through the app&apos;s features.</source>
-        <translation>Ce tour guidé de l'application vous fera découvrir ses fonctions.</translation>
+        <translation>Ce tour guidé de l&apos;application vous fera découvrir ses fonctions.</translation>
     </message>
     <message>
         <location filename="../src/AppTour.cpp" line="67"/>
@@ -107,7 +107,7 @@
         <source>Make sure your cartridge is properly inserted and its pins are clean.
 Do not remove the cartridge while any operation is running.</source>
         <translation>Assurez-vous que votre cartouche est correctement insérée et que ses broches sont propres.
-Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation>
+Ne retirez pas la cartouche pendant qu&apos;une opération est en cours.</translation>
     </message>
 </context>
 <context>
@@ -119,8 +119,8 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     </message>
     <message>
         <location filename="../src/CheatCodesScreen.cpp" line="101"/>
-        <source>Enable predefined cheats or use cheats from the internet to transform how you play, from abilities and mechanics to audio effects. Make sure you have autosave disabled so that your cartridge's save isn't overwritten while you're running cheats.</source>
-        <translation>Activez des codes prédéfinis pour tricher ou entrez des codes de triche venant du net pour transformer votre façon de jouer, allant d'une modification des capacités et mécanismes du jeu jusqu'à des changements sonores. Veuillez désactiver la sauvegarde automatique lorsque vous utilisez des codes de triche afin que la sauvegarde de votre cartouche ne soit pas écrasée en exécutant des codes.</translation>
+        <source>Enable predefined cheats or use cheats from the internet to transform how you play, from abilities and mechanics to audio effects. Make sure you have autosave disabled so that your cartridge&apos;s save isn&apos;t overwritten while you&apos;re running cheats.</source>
+        <translation>Activez des codes prédéfinis pour tricher ou entrez des codes de triche venant du net pour transformer votre façon de jouer, allant d&apos;une modification des capacités et mécanismes du jeu jusqu&apos;à des changements sonores. Veuillez désactiver la sauvegarde automatique lorsque vous utilisez des codes de triche afin que la sauvegarde de votre cartouche ne soit pas écrasée en exécutant des codes.</translation>
     </message>
 </context>
 <context>
@@ -174,17 +174,17 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/CoreCardWidget.cpp" line="277"/>
         <source>Failed to download core</source>
-        <translation>Le cœur n'a pas pu être téléchargé</translation>
+        <translation>Le cœur n&apos;a pas pu être téléchargé</translation>
     </message>
     <message>
         <location filename="../src/CoreCardWidget.cpp" line="284"/>
         <source>Failed to open file for writing</source>
-        <translation>Le fichier n'a pas pu être ouvert pour l'écriture</translation>
+        <translation>Le fichier n&apos;a pas pu être ouvert pour l&apos;écriture</translation>
     </message>
     <message>
         <location filename="../src/CoreCardWidget.cpp" line="294"/>
         <source>Failed to open zip file</source>
-        <translation>Le fichier zip n'a pas pu être ouvert</translation>
+        <translation>Le fichier zip n&apos;a pas pu être ouvert</translation>
     </message>
     <message>
         <location filename="../src/CoreCardWidget.cpp" line="336"/>
@@ -222,7 +222,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/CoreSelectorScreen.cpp" line="210"/>
         <source>You can change the emulation core for your Operator device. Download a core online or provide your own, but remember: only some cores are fully supported by Epilogue ensure complete feature compatibility.</source>
-        <translation>Vous pouvez changer le cœur d'émulation pour votre appareil Operator. Vous pouvez télécharger un cœur en ligne ou utiliser le votre, mais attention : seuls certains cœurs sont pleinement supportés par Epilogue pour s'assurer d'une compatibilité totale des fonctionnalités.</translation>
+        <translation>Vous pouvez changer le cœur d&apos;émulation pour votre appareil Operator. Vous pouvez télécharger un cœur en ligne ou utiliser le votre, mais attention : seuls certains cœurs sont pleinement supportés par Epilogue pour s&apos;assurer d&apos;une compatibilité totale des fonctionnalités.</translation>
     </message>
     <message>
         <location filename="../src/CoreSelectorScreen.cpp" line="212"/>
@@ -284,7 +284,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceBase.cpp" line="270"/>
         <source>Save data integrity check failed!</source>
-        <translation>La vérification de l'intégrité des données de sauvegarde a échoué !</translation>
+        <translation>La vérification de l&apos;intégrité des données de sauvegarde a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceBase.cpp" line="271"/>
@@ -297,12 +297,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="98"/>
         <source>Game Data Integrity Check Failed!</source>
-        <translation>La vérification de l'intégrité des données du jeu a échoué !</translation>
+        <translation>La vérification de l&apos;intégrité des données du jeu a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="99"/>
         <source>Playback detected a discrepancy between the expected game data and the backed up data. Please clean the cartridge pins and try again to ensure accuracy.</source>
-        <translation>Playback a détecté une différence entre les données du jeu attendues et les données copiées. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l'authenticité des données.</translation>
+        <translation>Playback a détecté une différence entre les données du jeu attendues et les données copiées. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l&apos;authenticité des données.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="132"/>
@@ -311,43 +311,43 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="133"/>
-        <source> It looks like the homebrew game you're trying to upload has been detected by Playback as having 0 bytes. Please verify that the data you're attempting to upload is accurate.</source>
+        <source> It looks like the homebrew game you&apos;re trying to upload has been detected by Playback as having 0 bytes. Please verify that the data you&apos;re attempting to upload is accurate.</source>
         <translation> Il semble que le jeu homebrew que vous essayez de téléverser ait été détecté par Playback comme ayant 0 octet. Veuillez vérifier que les données que vous essayez de téléverser sont correctes.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="143"/>
         <source>Upload Homebrew Command Failed!</source>
-        <translation>La commande de téléversement d'homebrew a échoué !</translation>
+        <translation>La commande de téléversement d&apos;homebrew a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="144"/>
         <source>An error occurred while attempting to start the homebrew upload command. Please restart the application and reconnect the Operator device. If the problem continues, contact our Support team.</source>
-        <translation>Une erreur s'est produite lors du lancement de la commande de téléversement d'homebrew. Veuillez redémarrer l'application et reconnecter l'appareil Operator. Si le problème persiste, contactez notre équipe d'assistance.</translation>
+        <translation>Une erreur s&apos;est produite lors du lancement de la commande de téléversement d&apos;homebrew. Veuillez redémarrer l&apos;application et reconnecter l&apos;appareil Operator. Si le problème persiste, contactez notre équipe d&apos;assistance.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="173"/>
         <source>Homebrew Cartridge Erase Failed!</source>
-        <translation>L'effacement des données de la cartouche homebrew a échoué !</translation>
+        <translation>L&apos;effacement des données de la cartouche homebrew a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="174"/>
-        <source>Playback couldn't delete the contents of the homebrew cartridge. Please clean the cartridge pins and try again. If the issue persists, contact our Support team.</source>
-        <translation>Playback n'a pas pu supprimer le contenu de la cartouche homebrew. Veuillez nettoyer les broches de la cartouche et réessayer. Si le problème persiste, contactez notre équipe d'assistance.</translation>
+        <source>Playback couldn&apos;t delete the contents of the homebrew cartridge. Please clean the cartridge pins and try again. If the issue persists, contact our Support team.</source>
+        <translation>Playback n&apos;a pas pu supprimer le contenu de la cartouche homebrew. Veuillez nettoyer les broches de la cartouche et réessayer. Si le problème persiste, contactez notre équipe d&apos;assistance.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="193"/>
         <source>Homebrew Cartridge Data Integrity Check Failed!</source>
-        <translation>La vérification de l'intégrité des données de la cartouche homebrew a échoué !</translation>
+        <translation>La vérification de l&apos;intégrité des données de la cartouche homebrew a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="194"/>
         <source>The cartridge was erased successfully, but the data written does not match the data read back. This issue might occur with some homebrew cartridges. Make sure the game is playable, either by testing on an original console or in the Playback app.</source>
-        <translation>Les données de la cartouche ont été effacées, mais les données écrites ne correspondent pas aux données relues. Ce problème peut se produire avec certaines cartouches homebrew. Assurez-vous que le jeu est jouable, soit en le testant sur une console d'origine, soit dans l'application Playback.</translation>
+        <translation>Les données de la cartouche ont été effacées, mais les données écrites ne correspondent pas aux données relues. Ce problème peut se produire avec certaines cartouches homebrew. Assurez-vous que le jeu est jouable, soit en le testant sur une console d&apos;origine, soit dans l&apos;application Playback.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="228"/>
         <source>Written game data integrity check failed</source>
-        <translation>La vérification de l'intégrité des données du jeu écrit a échoué</translation>
+        <translation>La vérification de l&apos;intégrité des données du jeu écrit a échoué</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="228"/>
@@ -357,22 +357,22 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="334"/>
         <source>Write save failed</source>
-        <translation>L'écriture de la sauvegarde a échoué</translation>
+        <translation>L&apos;écriture de la sauvegarde a échoué</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="334"/>
         <source>Failed to send write save command to device.</source>
-        <translation>Échec de l'envoi de l'écriture de la sauvegarde à l'appareil.</translation>
+        <translation>Échec de l&apos;envoi de l&apos;écriture de la sauvegarde à l&apos;appareil.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="363"/>
         <source>Save Data Integrity Check Failed!</source>
-        <translation>La vérification de l'intégrité des données de sauvegarde a échoué !</translation>
+        <translation>La vérification de l&apos;intégrité des données de sauvegarde a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="364"/>
         <source>The save data written to the cartridge does not match the data read back. Please clean the cartridge pins and try again to ensure consistency.</source>
-        <translation>Les données de sauvegarde écrites dans la cartouche ne correspondent pas aux données relues. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l'authenticité des données.</translation>
+        <translation>Les données de sauvegarde écrites dans la cartouche ne correspondent pas aux données relues. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l&apos;authenticité des données.</translation>
     </message>
 </context>
 <context>
@@ -385,7 +385,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceSettingsScreen.cpp" line="69"/>
         <source>Choose one of the options below to set the status of your device’s LED light. Select ‘Static’ to keep the light on or ‘Dark’ to shut it off. Pulse and Strobe coming soon.</source>
-        <translation>Choisissez l'une des options ci-dessous pour changer l'état de la lumière LED de votre appareil. Sélectionnez « Statique » pour que la lumière reste allumée ou « Sombre » pour l'éteindre. Les options « Pulsation » et « Stroboscopique » seront bientôt disponibles.</translation>
+        <translation>Choisissez l&apos;une des options ci-dessous pour changer l&apos;état de la lumière LED de votre appareil. Sélectionnez « Statique » pour que la lumière reste allumée ou « Sombre » pour l&apos;éteindre. Les options « Pulsation » et « Stroboscopique » seront bientôt disponibles.</translation>
     </message>
 </context>
 <context>
@@ -421,7 +421,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/Emulator.cpp" line="262"/>
         <source>Unable to launch the game, please make sure that the cartridge is clean.</source>
-        <translation>Le jeu n'a pas pu être démarré : assurez-vous que la cartouche est propre.</translation>
+        <translation>Le jeu n&apos;a pas pu être démarré : assurez-vous que la cartouche est propre.</translation>
     </message>
     <message>
         <location filename="../src/Emulator.cpp" line="268"/>
@@ -431,7 +431,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/Emulator.cpp" line="268"/>
         <source>The core failed to load the save data.</source>
-        <translation>Le cœur n'a pas réussi à charger les données de sauvegarde.</translation>
+        <translation>Le cœur n&apos;a pas réussi à charger les données de sauvegarde.</translation>
     </message>
 </context>
 <context>
@@ -453,12 +453,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="251"/>
         <source>Fast-forward speed multiplier (Re-enable)</source>
-        <translation>Multiplicateur de vitesse de l'avance rapide (Réactivation)</translation>
+        <translation>Multiplicateur de vitesse de l&apos;avance rapide (Réactivation)</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="260"/>
-        <source>A fast-forward speed higher than 2x can cause unexpected bugs in combination with the 'Autosave to cartridge' feature. You will need to disable and enable it by clicking the fast-forward button.</source>
-        <translation>Une avance rapide supérieure à 2x peut provoquer des bugs inattendus en combinaison avec la fonction « Sauvegarder automatiquement sur la cartouche ». Vous devrez désactiver et activer l'avance rapide en appuyant sur le bouton d'avance rapide en jouant.</translation>
+        <source>A fast-forward speed higher than 2x can cause unexpected bugs in combination with the &apos;Autosave to cartridge&apos; feature. You will need to disable and enable it by clicking the fast-forward button.</source>
+        <translation>Une avance rapide supérieure à 2x peut provoquer des bugs inattendus en combinaison avec la fonction « Sauvegarder automatiquement sur la cartouche ». Vous devrez désactiver et activer l&apos;avance rapide en appuyant sur le bouton d&apos;avance rapide en jouant.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="252"/>
@@ -473,7 +473,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="238"/>
         <source>Input &amp; Auxiliary Devices</source>
-        <translation>Dispositifs d'entrée et auxiliaires</translation>
+        <translation>Dispositifs d&apos;entrée et auxiliaires</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="239"/>
@@ -498,7 +498,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="265"/>
         <source>Enables high-fidelity mode, making audio and video run at rates close to what you would encounter on the original hardware. This will increase CPU usage, disable it if you notice low framerates.</source>
-        <translation>Active le mode haute fidélité, permettant de faire fonctionner l'audio et la vidéo à des taux proches de ceux que vous rencontreriez sur la console d'origine. Cela augmentera l'utilisation du processeur, donc désactivez cette option si vous remarquez des taux d'images faibles.</translation>
+        <translation>Active le mode haute fidélité, permettant de faire fonctionner l&apos;audio et la vidéo à des taux proches de ceux que vous rencontreriez sur la console d&apos;origine. Cela augmentera l&apos;utilisation du processeur, donc désactivez cette option si vous remarquez des taux d&apos;images faibles.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="300"/>
@@ -518,7 +518,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="270"/>
         <source>Enable rumble support for games that support it, for more compatibility make sure you also enable Game Boy Player Rumble.</source>
-        <translation>Activez les vibrations pour les jeux compatibles. Pour fonctionner avec le plus de jeux compatibles, assurez-vous d'activer également la Vibration Game Boy Player.</translation>
+        <translation>Activez les vibrations pour les jeux compatibles. Pour fonctionner avec le plus de jeux compatibles, assurez-vous d&apos;activer également la Vibration Game Boy Player.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="254"/>
@@ -528,7 +528,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.cpp" line="273"/>
         <source>Enable in-game integrity checks for save data. This feature is still in beta and may not work with all games.</source>
-        <translation>Activer les vérifications d'intégrité en jeu pour les données de sauvegarde. Cette fonctionnalité est encore en version bêta et peut ne pas fonctionner avec tous les jeux.</translation>
+        <translation>Activer les vérifications d&apos;intégrité en jeu pour les données de sauvegarde. Cette fonctionnalité est encore en version bêta et peut ne pas fonctionner avec tous les jeux.</translation>
     </message>
 </context>
 <context>
@@ -541,7 +541,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/UIComponents.cpp" line="130"/>
         <source>Please DO NOT disconnect or turn off your device during the update process. The LED will turn off during the update. Interruption will lead to your device becoming unusable and void warranty. By agreeing to this message box you confirm your understanding of these instructions.</source>
-        <translation>Veuillez NE PAS déconnecter ou éteindre votre appareil pendant la mise à jour. La LED s'éteindra pendant la mise à jour. Toute interruption rendra votre appareil inutilisable et annulera la garantie. En acceptant cette boîte de message, vous confirmez votre compréhension de ces instructions.</translation>
+        <translation>Veuillez NE PAS déconnecter ou éteindre votre appareil pendant la mise à jour. La LED s&apos;éteindra pendant la mise à jour. Toute interruption rendra votre appareil inutilisable et annulera la garantie. En acceptant cette boîte de message, vous confirmez votre compréhension de ces instructions.</translation>
     </message>
 </context>
 <context>
@@ -556,7 +556,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
         <source>This may take up to a minute,
 please do not disconnect the device.</source>
         <translation>Cela peut prendre une minute,
-veuillez ne pas déconnectez l'appareil.</translation>
+veuillez ne pas déconnectez l&apos;appareil.</translation>
     </message>
     <message>
         <location filename="../src/FirmwareUpdateWindow.cpp" line="60"/>
@@ -574,7 +574,7 @@ veuillez ne pas déconnectez l'appareil.</translation>
     <message>
         <location filename="../src/InputBindingsScreen.cpp" line="178"/>
         <source>Need help?</source>
-        <translation>Besoin d'aide ?</translation>
+        <translation>Besoin d&apos;aide ?</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.cpp" line="179"/>
@@ -584,11 +584,11 @@ veuillez ne pas déconnectez l'appareil.</translation>
     <message>
         <location filename="../src/InputBindingsScreen.cpp" line="170"/>
         <source>The Playback software comes with pre-configured bindings for most gamepads. Try pressing buttons on your controller or keyboard to test them.</source>
-        <translation>Le logiciel Playback contient des configurations par défaut pour la plupart des manettes de jeu. Essayez d'appuyer sur les boutons de votre manette ou sur les touches de votre clavier pour les tester.</translation>
+        <translation>Le logiciel Playback contient des configurations par défaut pour la plupart des manettes de jeu. Essayez d&apos;appuyer sur les boutons de votre manette ou sur les touches de votre clavier pour les tester.</translation>
     </message>
     <message>
         <source>No gamepads connected.</source>
-        <translation type="vanished">Aucune manette n'est connectée.</translation>
+        <translation type="vanished">Aucune manette n&apos;est connectée.</translation>
     </message>
     <message>
         <source>Select a gamepad</source>
@@ -605,7 +605,7 @@ veuillez ne pas déconnectez l'appareil.</translation>
     <message>
         <location filename="../src/UIComponents.cpp" line="59"/>
         <source>Integrity check failed!</source>
-        <translation>Le contrôle d'intégrité a échoué !</translation>
+        <translation>Le contrôle d&apos;intégrité a échoué !</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="60"/>
@@ -613,9 +613,9 @@ veuillez ne pas déconnectez l'appareil.</translation>
 
 You can try cleaning then re-inserting the cartridge into the device.
 </source>
-        <translation>Nous n'avons pas pu confirmer l'intégrité des données de cette cartouche, souhaitez-vous quand même continuer ? Il se peut que le jeu ne fonctionne pas ou ne sauvegarde pas correctement.
+        <translation>Nous n&apos;avons pas pu confirmer l&apos;intégrité des données de cette cartouche, souhaitez-vous quand même continuer ? Il se peut que le jeu ne fonctionne pas ou ne sauvegarde pas correctement.
 
-Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil.
+Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l&apos;appareil.
 </translation>
     </message>
 </context>
@@ -624,12 +624,12 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="113"/>
         <source>Permission denied. Unable to open device.</source>
-        <translation>Permission refusée. Impossible d'ouvrir l'appareil.</translation>
+        <translation>Permission refusée. Impossible d&apos;ouvrir l&apos;appareil.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="115"/>
         <source>Please make sure you configure your Linux system to allow unprivileged access to serial ports.</source>
-        <translation>Veuillez configurer votre système Linux afin d'autoriser l'accès non privilégié aux ports série.</translation>
+        <translation>Veuillez configurer votre système Linux afin d&apos;autoriser l&apos;accès non privilégié aux ports série.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="116"/>
@@ -644,7 +644,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="117"/>
         <source>to configure your Operator device.</source>
-        <translation>pour configurer l'Operator.</translation>
+        <translation>pour configurer l&apos;Operator.</translation>
     </message>
 </context>
 <context>
@@ -652,12 +652,12 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="87"/>
         <source>Integrity check failed!</source>
-        <translation>Le contrôle d'intégrité a échoué !</translation>
+        <translation>Le contrôle d&apos;intégrité a échoué !</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="88"/>
         <source>Your Operator device did not manage to read your cartridge properly. Please make sure that the cartridge is clean and try again.</source>
-        <translation>Votre appareil Operator n'a pas réussi à lire correctement votre cartouche. Assurez-vous que la cartouche est propre et réessayez.</translation>
+        <translation>Votre appareil Operator n&apos;a pas réussi à lire correctement votre cartouche. Assurez-vous que la cartouche est propre et réessayez.</translation>
     </message>
 </context>
 <context>
@@ -731,7 +731,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="102"/>
         <source>It looks like there is another instance of the software running on this computer. Closing this instance.</source>
-        <translation>Il semble qu'une autre instance du logiciel soit en cours d'exécution sur cet ordinateur. Veuillez fermer cette instance.</translation>
+        <translation>Il semble qu&apos;une autre instance du logiciel soit en cours d&apos;exécution sur cet ordinateur. Veuillez fermer cette instance.</translation>
     </message>
 </context>
 <context>
@@ -740,7 +740,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
         <location filename="../src/Navbar.cpp" line="207"/>
         <location filename="../src/Navbar.cpp" line="242"/>
         <source>Press ESC to exit emulation</source>
-        <translation>Appuyez sur ÉCHAP pour quitter l'émulation</translation>
+        <translation>Appuyez sur ÉCHAP pour quitter l&apos;émulation</translation>
     </message>
     <message>
         <location filename="../src/Navbar.cpp" line="241"/>
@@ -805,7 +805,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     </message>
     <message>
         <location filename="../src/NavbarLogoDropdown.cpp" line="123"/>
-        <source>What's New</source>
+        <source>What&apos;s New</source>
         <translation>Nouveautés</translation>
     </message>
     <message>
@@ -913,7 +913,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/PhotosPage.cpp" line="322"/>
         <source>Found no photos on your Game Boy Camera.</source>
-        <translation>Aucune photo n'a été trouvée sur votre Game Boy Camera.</translation>
+        <translation>Aucune photo n&apos;a été trouvée sur votre Game Boy Camera.</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="350"/>
@@ -924,7 +924,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
         <location filename="../src/PhotosPage.cpp" line="344"/>
         <source>Transfer your pics from your Game Boy Camera to your PC in just two clicks. The images are stored as PNGs of 128x112 pixels. You can scale this using the scaling function.
 
-If you'd like to easily remove all the pictures from your camera, without having to manually delete them one by one in the camera software, you can use the delete button below.</source>
+If you&apos;d like to easily remove all the pictures from your camera, without having to manually delete them one by one in the camera software, you can use the delete button below.</source>
         <translation>Transférez vos photos de votre Game Boy Camera vers votre PC en deux clics. Les images sont stockées au format PNG en 128x112 pixels. Vous pouvez ajuster leur taille en sélectionnant le bouton Taille.
 
 Si vous souhaitez supprimer facilement toutes les images de votre caméra sans avoir à les supprimer manuellement une par une dans le logiciel de la caméra, vous pouvez utiliser le bouton de suppression ci-dessous.</translation>
@@ -953,7 +953,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="105"/>
         <source>Allows you to change the language in which the Playback software is presented. It requires an application restart in order to update the language accross the entire application.</source>
-        <translation>Permet de changer la langue dans laquelle le logiciel Playback est affiché. Un redémarrage de l'application est nécessaire pour mettre à jour la langue dans l'ensemble de l'application.</translation>
+        <translation>Permet de changer la langue dans laquelle le logiciel Playback est affiché. Un redémarrage de l&apos;application est nécessaire pour mettre à jour la langue dans l&apos;ensemble de l&apos;application.</translation>
     </message>
     <message>
         <source>Autosave to cartridge (beta)</source>
@@ -975,20 +975,20 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="93"/>
         <source>FPS Counter</source>
-        <translation>Compteur d'IPS</translation>
+        <translation>Compteur d&apos;IPS</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="113"/>
         <source>Displays the current frames per second (FPS) of the game being played.</source>
-        <translation>Affiche le nombre d'images par seconde (IPS) du jeu en cours.</translation>
+        <translation>Affiche le nombre d&apos;images par seconde (IPS) du jeu en cours.</translation>
     </message>
     <message>
         <source>Preferred emulator core</source>
-        <translation type="obsolete">Cœur d'émulateur préféré</translation>
+        <translation type="obsolete">Cœur d&apos;émulateur préféré</translation>
     </message>
     <message>
-        <source>Allows you to select the preferred emulation core for running games. Different cores may offer varying levels of accuracy, performance, or compatibility with specific games. Choose the core that best suits your needs and the game you're playing.</source>
-        <translation type="obsolete">Permet de sélectionner le cœur d'émulation préféré pour l'exécution des jeux. Les différents cœurs peuvent offrir différents niveaux de précision, de performance ou de compatibilité avec des jeux spécifiques. Choisissez le cœur correspondant au mieux à vos besoins et au jeu auquel vous jouez.</translation>
+        <source>Allows you to select the preferred emulation core for running games. Different cores may offer varying levels of accuracy, performance, or compatibility with specific games. Choose the core that best suits your needs and the game you&apos;re playing.</source>
+        <translation type="obsolete">Permet de sélectionner le cœur d&apos;émulation préféré pour l&apos;exécution des jeux. Les différents cœurs peuvent offrir différents niveaux de précision, de performance ou de compatibilité avec des jeux spécifiques. Choisissez le cœur correspondant au mieux à vos besoins et au jeu auquel vous jouez.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="92"/>
@@ -1003,12 +1003,12 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="115"/>
         <source>When enabled and supported by the game, Playback adds real-time clock (RTC) data to the save file. This ensures accurate preservation of time-based events. Note that this will increase the file size and might make it incompatible with other software.</source>
-        <translation>Lorsqu'activé et pris en charge par le jeu, Playback ajoute les données de l'horloge temps réel (HTR) au fichier de sauvegarde. Cela permet de conserver fidèlement les événements liés au temps. Notez que cela augmente la taille du fichier et peut le rendre incompatible avec d'autres logiciels.</translation>
+        <translation>Lorsqu&apos;activé et pris en charge par le jeu, Playback ajoute les données de l&apos;horloge temps réel (HTR) au fichier de sauvegarde. Cela permet de conserver fidèlement les événements liés au temps. Notez que cela augmente la taille du fichier et peut le rendre incompatible avec d&apos;autres logiciels.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="95"/>
         <source>Verify Save After Writing Process</source>
-        <translation>Vérifier la sauvegarde après l'écriture</translation>
+        <translation>Vérifier la sauvegarde après l&apos;écriture</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="91"/>
@@ -1018,7 +1018,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="119"/>
         <source>Activating this setting prompts Playback to check that the save file remains uncorrupted after being written to the cartridge. It ensures your game progress has been safely stored.</source>
-        <translation>Activer ce paramètre force Playback à vérifier que le fichier de sauvegarde n'a pas été corrompu après avoir été écrit sur la cartouche. Cela permet de s'assurer que les données du jeu ont été sauvegardées en toute sécurité.</translation>
+        <translation>Activer ce paramètre force Playback à vérifier que le fichier de sauvegarde n&apos;a pas été corrompu après avoir été écrit sur la cartouche. Cela permet de s&apos;assurer que les données du jeu ont été sauvegardées en toute sécurité.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="96"/>
@@ -1028,17 +1028,17 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="122"/>
         <source>When this setting is enabled, Playback reads the save file from the cartridge multiple times and reviews any discrepancies to prevent data corruption.</source>
-        <translation>Lorsque ce paramètre est activé, l'application lit plusieurs fois la sauvegarde de la cartouche et examine toute anomalie afin d'éviter la corruption des données.</translation>
+        <translation>Lorsque ce paramètre est activé, l&apos;application lit plusieurs fois la sauvegarde de la cartouche et examine toute anomalie afin d&apos;éviter la corruption des données.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="97"/>
         <source>Verify Homebrew File Integrity</source>
-        <translation>Vérifier l'intégrité des données du fichier homebrew</translation>
+        <translation>Vérifier l&apos;intégrité des données du fichier homebrew</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="125"/>
         <source>This setting enables Playback to confirm the integrity of a homebrew game after transferring it to the cartridge, making sure there are no issues affecting your work.</source>
-        <translation>Ce paramètre force Playback à confirmer l'intégrité d'un jeu homebrew après l'avoir transféré sur la cartouche, afin de s'assurer qu'aucun problème n'affecte votre travail.</translation>
+        <translation>Ce paramètre force Playback à confirmer l&apos;intégrité d&apos;un jeu homebrew après l&apos;avoir transféré sur la cartouche, afin de s&apos;assurer qu&apos;aucun problème n&apos;affecte votre travail.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="98"/>
@@ -1048,7 +1048,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="128"/>
         <source>When enabled, the Playback software will output more detailed logs to help diagnose issues. This setting is useful for troubleshooting and should be disabled when not needed.</source>
-        <translation>Lorsque cette option est activée, Playback produit des journaux plus détaillés pour aider à diagnostiquer les problèmes. Ce paramètre est utile pour le dépannage et doit être désactivé lorsqu'il n'est pas nécessaire.</translation>
+        <translation>Lorsque cette option est activée, Playback produit des journaux plus détaillés pour aider à diagnostiquer les problèmes. Ce paramètre est utile pour le dépannage et doit être désactivé lorsqu&apos;il n&apos;est pas nécessaire.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="78"/>
@@ -1121,7 +1121,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/AboutWindow.cpp" line="153"/>
         <source>Device Version</source>
-        <translation>Version de l'appareil</translation>
+        <translation>Version de l&apos;appareil</translation>
     </message>
     <message>
         <location filename="../src/AboutWindow.cpp" line="154"/>
@@ -1141,7 +1141,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
     <message>
         <location filename="../src/CartDetailsWidget.cpp" line="292"/>
         <source>The description of this cartridge can’t be displayed since it’s not in our database. You can use the link below to open a ticket and we’ll add the game info to the database. Please feel free to contact us even if it’s a homebrew game you made if you’d like to have your artwork displayed here.</source>
-        <translation>La description de cette cartouche ne peut être affichée car elle n'est pas dans notre base de données. Vous pouvez utiliser le lien ci-dessous pour ouvrir un ticket et nous ajouterons les informations du jeu dans la base de données. N'hésitez pas à nous contacter même s'il s'agit d'un jeu homebrew que vous avez créé si vous souhaitez que votre jaquette soit affichée ici.</translation>
+        <translation>La description de cette cartouche ne peut être affichée car elle n&apos;est pas dans notre base de données. Vous pouvez utiliser le lien ci-dessous pour ouvrir un ticket et nous ajouterons les informations du jeu dans la base de données. N&apos;hésitez pas à nous contacter même s&apos;il s&apos;agit d&apos;un jeu homebrew que vous avez créé si vous souhaitez que votre jaquette soit affichée ici.</translation>
     </message>
     <message>
         <location filename="../src/CartDetailsWidget.cpp" line="299"/>
@@ -1178,18 +1178,18 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra sans a
         <source>Archive your game data securely on your computer, making a digital equivalent of your game collection. Game files are compatible with your chosen emulator.
 
 Tip: Our app runs a Data Integrity Test to make sure that you are getting an accurate reproduction of the cartridge’s content.</source>
-        <translation>Archivez vos données de jeu en toute sécurité sur votre ordinateur et créez un équivalent numérique de votre collection de jeux. Les fichiers de jeu sont compatibles avec l'émulateur de votre choix.
+        <translation>Archivez vos données de jeu en toute sécurité sur votre ordinateur et créez un équivalent numérique de votre collection de jeux. Les fichiers de jeu sont compatibles avec l&apos;émulateur de votre choix.
 
-Astuce : Notre application effectue une vérification de l'intégrité des données pour s'assurer que vous obtenez une reproduction exacte du contenu de la cartouche.</translation>
+Astuce : Notre application effectue une vérification de l&apos;intégrité des données pour s&apos;assurer que vous obtenez une reproduction exacte du contenu de la cartouche.</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.cpp" line="119"/>
         <source>Overwrite the game data on your cartridge with a different file. Make sure the game file you’re writing is valid by testing it in an external emulator first.
 
 Tip: Transfer your homebrew game to a cartridge and play it on original hardware.</source>
-        <translation>Remplacez les données de jeu de votre cartouche par un autre fichier. Assurez-vous que le fichier de jeu que vous écrivez est valide en le testant d'abord dans un émulateur externe.
+        <translation>Remplacez les données de jeu de votre cartouche par un autre fichier. Assurez-vous que le fichier de jeu que vous écrivez est valide en le testant d&apos;abord dans un émulateur externe.
 
-Astuce : transférez votre jeu homebrew sur une cartouche et jouez-y sur la console d'origine.</translation>
+Astuce : transférez votre jeu homebrew sur une cartouche et jouez-y sur la console d&apos;origine.</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.cpp" line="125"/>
@@ -1198,14 +1198,14 @@ Astuce : transférez votre jeu homebrew sur une cartouche et jouez-y sur la cons
 Tip: Transfer your save to the computer, replace the battery and transfer it back to the cartridge safely.</source>
         <translation>Transférez une copie de vos données de sauvegarde de votre cartouche vers votre ordinateur. Vous pourrez alors sauvegarder votre fichier de sauvegarde ou le modifier avec un programme externe.
 
-Astuce : transférez votre sauvegarde sur l'ordinateur, remplacez la batterie et transférez-la à nouveau sur la cartouche en toute sécurité.</translation>
+Astuce : transférez votre sauvegarde sur l&apos;ordinateur, remplacez la batterie et transférez-la à nouveau sur la cartouche en toute sécurité.</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.cpp" line="134"/>
         <source>Transfer a duplicate of your save data from your computer to the cartridge and pick the game up right where you left off.
 
 Tip: Use external programs to trigger in-game events or customize gameplay.</source>
-        <translation>Transférez une copie de vos données de sauvegarde de votre ordinateur vers la cartouche et reprenez le jeu là où vous l'avez laissé.
+        <translation>Transférez une copie de vos données de sauvegarde de votre ordinateur vers la cartouche et reprenez le jeu là où vous l&apos;avez laissé.
 
 Astuce : utilisez des programmes externes pour déclencher des événements dans le jeu ou en modifier le gameplay.</translation>
     </message>
@@ -1253,7 +1253,7 @@ You can read more about this issue here. Backups of the original save on the car
 
 Would you like to proceed?
 </source>
-        <translation>Le cœur de l'émulateur signale actuellement une taille de sauvegarde différente de celle que nous avons détectée sur la cartouche.
+        <translation>Le cœur de l&apos;émulateur signale actuellement une taille de sauvegarde différente de celle que nous avons détectée sur la cartouche.
 
 Vous pouvez en savoir plus sur ce problème ici. Des copies de la sauvegarde originale sur la cartouche sont effectuées dans le coffre-fort, mais continuer pourrait créer des sauvegardes inutilisables.
 
@@ -1271,9 +1271,9 @@ Souhaitez-vous tout de même continuer ?
     <message>
         <location filename="../src/SearchWindow.cpp" line="53"/>
         <source>Looking for your Operator device.
-Please make sure it's connected.</source>
-        <translation>Recherche de l'appareil Operator.
-Assurez-vous qu'il est connecté.</translation>
+Please make sure it&apos;s connected.</source>
+        <translation>Recherche de l&apos;appareil Operator.
+Assurez-vous qu&apos;il est connecté.</translation>
     </message>
     <message>
         <location filename="../src/SearchWindow.cpp" line="55"/>
@@ -1293,7 +1293,7 @@ Assurez-vous qu'il est connecté.</translation>
     </message>
     <message>
         <source>Input &amp; Auxiliary Devices</source>
-        <translation type="obsolete">Dispositifs d'entrée et auxiliaires</translation>
+        <translation type="obsolete">Dispositifs d&apos;entrée et auxiliaires</translation>
     </message>
     <message>
         <source>Configure controller and controller rumble settings.</source>
@@ -1310,7 +1310,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/SettingsWindow.cpp" line="246"/>
         <source>Failed to load core. Please load a valid core.</source>
-        <translation>Le cœur n'a pas pu être chargé. Veuillez charger un cœur valide.</translation>
+        <translation>Le cœur n&apos;a pas pu être chargé. Veuillez charger un cœur valide.</translation>
     </message>
     <message>
         <location filename="../src/SettingsWindow.cpp" line="276"/>
@@ -1325,12 +1325,12 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/SettingsWindow.cpp" line="279"/>
         <source>Emulator Settings</source>
-        <translation>Paramètres de l'émulateur</translation>
+        <translation>Paramètres de l&apos;émulateur</translation>
     </message>
     <message>
         <location filename="../src/SettingsWindow.cpp" line="280"/>
         <source>Device Settings</source>
-        <translation>Paramètres de l'appareil</translation>
+        <translation>Paramètres de l&apos;appareil</translation>
     </message>
     <message>
         <location filename="../src/SettingsWindow.cpp" line="281"/>
@@ -1438,7 +1438,7 @@ Assurez-vous qu'il est connecté.</translation>
         <location filename="../src/Window.cpp" line="138"/>
         <location filename="../src/Window.cpp" line="368"/>
         <source>A new app update is available</source>
-        <translation>Une nouvelle mise à jour de l'application est disponible</translation>
+        <translation>Une nouvelle mise à jour de l&apos;application est disponible</translation>
     </message>
     <message>
         <location filename="../src/Window.cpp" line="138"/>
@@ -1450,7 +1450,7 @@ Assurez-vous qu'il est connecté.</translation>
         <location filename="../src/Window.cpp" line="159"/>
         <location filename="../src/Window.cpp" line="366"/>
         <source>A new device update is available</source>
-        <translation>Une nouvelle mise à jour de l'appareil est disponible</translation>
+        <translation>Une nouvelle mise à jour de l&apos;appareil est disponible</translation>
     </message>
     <message>
         <location filename="../src/Window.cpp" line="159"/>
@@ -1476,7 +1476,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/Window.cpp" line="402"/>
         <source>Experience original console behavior with cycle-accurate emulation settings</source>
-        <translation>Vivez le comportement de la console d'origine avec des paramètres d'émulation aux cycles fidèles</translation>
+        <translation>Vivez le comportement de la console d&apos;origine avec des paramètres d&apos;émulation aux cycles fidèles</translation>
     </message>
     <message>
         <location filename="../src/Window.cpp" line="409"/>

--- a/main_fr.ts
+++ b/main_fr.ts
@@ -4,7 +4,7 @@
     <message>
         <location filename="../src/AboutWindow.cpp" line="14" />
         <source>About</source>
-        <translation>A propos de</translation>
+        <translation>À propos</translation>
     </message>
     <message>
         <location filename="../src/AboutWindow.cpp" line="71" />
@@ -14,12 +14,12 @@
     <message>
         <location filename="../src/AboutWindow.cpp" line="111" />
         <source>Copyright Notices</source>
-        <translation type="unfinished">Avis de droit d'auteur</translation>
+        <translation>Mentions de copyright</translation>
     </message>
     <message>
         <location filename="../src/AboutWindow.cpp" line="112" />
         <source>Software License Agreement</source>
-        <translation>Accord de licence de logiciel</translation>
+        <translation>Accord de licence logiciel</translation>
     </message>
 </context>
 <context>
@@ -27,7 +27,7 @@
     <message>
         <location filename="../src/UIComponents.cpp" line="118" />
         <source>beta</source>
-        <translation type="unfinished">bêta</translation>
+        <translation>bêta</translation>
     </message>
 </context>
 <context>
@@ -78,12 +78,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/CheatCodesScreen.h" line="36" />
         <source>Cheat Codes</source>
-        <translation type="unfinished">Codes de triche</translation>
+        <translation>Codes de triche</translation>
     </message>
     <message>
         <location filename="../src/CheatCodesScreen.h" line="38" />
         <source>Enable predefined cheats or use cheats from the internet to transform how you play, from abilities and mechanics to audio effects. Make sure you have autosave disabled so that your cartridge's save isn't overwritten while you're running cheats.</source>
-        <translation type="unfinished">Activez des triches prédéfinies ou utilisez des triches sur Internet pour transformer votre façon de jouer, depuis les capacités et les mécanismes jusqu'aux effets audio. Veillez à désactiver la fonction de sauvegarde automatique afin que la sauvegarde de votre cartouche ne soit pas écrasée lorsque vous exécutez des tricheries.</translation>
+        <translation>Activez des codes prédéfinis pour tricher ou entrez des codes de triche venant du net pour transformer votre façon de jouer, allant d'une modification des capacités et mécanismes du jeu jusqu'à des changements sonores. Veuillez désactiver la sauvegarde automatique lorsque vous utilisez des codes de triche afin que la sauvegarde de votre cartouche ne soit pas écrasée en exécutant des codes.</translation>
     </message>
 </context>
 <context>
@@ -91,12 +91,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/ControlsWidget.cpp" line="59" />
         <source>Player: </source>
-        <translation type="unfinished">Joueur :</translation>
+        <translation>Joueur :</translation>
     </message>
     <message>
         <location filename="../src/ControlsWidget.cpp" line="135" />
         <source>Input: </source>
-        <translation type="unfinished">Entrée :</translation>
+        <translation>Entrée :</translation>
     </message>
 </context>
 <context>
@@ -104,22 +104,22 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/CustomCheatCodesWidget.cpp" line="9" />
         <source>Custom Cheats</source>
-        <translation type="unfinished">Tricheurs personnalisés</translation>
+        <translation>Codes de triche personnalisés</translation>
     </message>
     <message>
         <location filename="../src/CustomCheatCodesWidget.cpp" line="35" />
         <source>Description</source>
-        <translation type="unfinished">Description</translation>
+        <translation>Description</translation>
     </message>
     <message>
         <location filename="../src/CustomCheatCodesWidget.cpp" line="36" />
         <source>Code</source>
-        <translation type="unfinished">Code</translation>
+        <translation>Code</translation>
     </message>
     <message>
         <location filename="../src/CustomCheatCodesWidget.cpp" line="31" />
         <source>Enabled</source>
-        <translation type="unfinished">Activé</translation>
+        <translation>Activé</translation>
     </message>
 </context>
 <context>
@@ -127,7 +127,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DatabaseCheatCodesWidget.cpp" line="8" />
         <source> Default Cheats</source>
-        <translation type="unfinished"> Triche par défaut</translation>
+        <translation> - Codes prédéfinis</translation>
     </message>
 </context>
 <context>
@@ -135,12 +135,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceBase.cpp" line="266" />
         <source>Save data integrity check failed!</source>
-        <translation type="unfinished">Le contrôle de l'intégrité des données enregistrées a échoué !</translation>
+        <translation>La vérification de l'intégrité des données de sauvegarde a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceBase.cpp" line="267" />
         <source>The save data appears to be inconsistent between read cycles. Please clean the cartridge pins and try again.</source>
-        <translation type="unfinished">Les données de sauvegarde semblent incohérentes entre les cycles de lecture. Veuillez nettoyer les broches de la cartouche et réessayer.</translation>
+        <translation>Les données de sauvegarde semblent inconsistentes entre les différentes lectures. Veuillez nettoyer les broches de la cartouche et réessayer.</translation>
     </message>
 </context>
 <context>
@@ -148,82 +148,82 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="98" />
         <source>Game Data Integrity Check Failed!</source>
-        <translation type="unfinished">Le contrôle de l'intégrité des données du jeu a échoué !</translation>
+        <translation>La vérification de l'intégrité des données du jeu a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="99" />
         <source>Playback detected a discrepancy between the expected game data and the backed up data. Please clean the cartridge pins and try again to ensure accuracy.</source>
-        <translation type="unfinished">La lecture a détecté une divergence entre les données de jeu attendues et les données sauvegardées. Veuillez nettoyer les broches de la cartouche et réessayer pour garantir la précision.</translation>
+        <translation>Playback a détecté une différence entre les données du jeu attendues et les données copiées. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l'authenticité des données.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="133" />
         <source>Empty File Was Provided!</source>
-        <translation type="unfinished">Un fichier vide a été fourni !</translation>
+        <translation>Un fichier vide a été fourni !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="134" />
         <source> It looks like the homebrew game you're trying to upload has been detected by Playback as having 0 bytes. Please verify that the data you're attempting to upload is accurate.</source>
-        <translation type="unfinished"> Il semble que le jeu homebrew que vous essayez de télécharger ait été détecté par Playback comme ayant 0 octet. Veuillez vérifier que les données que vous essayez de télécharger sont exactes.</translation>
+        <translation> Il semble que le jeu homebrew que vous essayez de téléverser ait été détecté par Playback comme ayant 0 octet. Veuillez vérifier que les données que vous essayez de téléverser sont correctes.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="145" />
         <source>Upload Homebrew Command Failed!</source>
-        <translation type="unfinished">La commande Upload Homebrew a échoué !</translation>
+        <translation>La commande de téléversement d'homebrew a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="146" />
         <source>An error occurred while attempting to start the homebrew upload command. Please restart the application and reconnect the Operator device. If the problem continues, contact our Support team.</source>
-        <translation type="unfinished">Une erreur s'est produite lors de la tentative de lancement de la commande de téléchargement homebrew. Veuillez redémarrer l'application et reconnecter l'appareil de l'opérateur. Si le problème persiste, contactez notre équipe d'assistance.</translation>
+        <translation>Une erreur s'est produite lors du lancement de la commande de téléversement d'homebrew. Veuillez redémarrer l'application et reconnecter l'appareil Operator. Si le problème persiste, contactez notre équipe d'assistance.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="175" />
         <source>Homebrew Cartridge Erase Failed!</source>
-        <translation type="unfinished">Échec de l'effacement de la cartouche Homebrew !</translation>
+        <translation>L'effacement des données de la cartouche homebrew a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="176" />
         <source>Playback couldn't delete the contents of the homebrew cartridge. Please clean the cartridge pins and try again. If the issue persists, contact our Support team.</source>
-        <translation type="unfinished">La lecture n'a pas pu supprimer le contenu de la cartouche homebrew. Veuillez nettoyer les broches de la cartouche et réessayer. Si le problème persiste, contactez notre équipe d'assistance.</translation>
+        <translation>Playback n'a pas pu supprimer le contenu de la cartouche homebrew. Veuillez nettoyer les broches de la cartouche et réessayer. Si le problème persiste, contactez notre équipe d'assistance.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="196" />
         <source>Homebrew Cartridge Data Integrity Check Failed!</source>
-        <translation type="unfinished">Échec de la vérification de l'intégrité des données de la cartouche Homebrew !</translation>
+        <translation>La vérification de l'intégrité des données de la cartouche homebrew a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="197" />
         <source>The cartridge was erased successfully, but the data written does not match the data read back. This issue might occur with some homebrew cartridges. Make sure the game is playable, either by testing on an original console or in the Playback app.</source>
-        <translation type="unfinished">La cartouche a été effacée avec succès, mais les données écrites ne correspondent pas aux données relues. Ce problème peut se produire avec certaines cartouches homebrew. Assurez-vous que le jeu est jouable, soit en le testant sur une console d'origine, soit dans l'application Playback.</translation>
+        <translation>Les données de la cartouche ont été effacées, mais les données écrites ne correspondent pas aux données relues. Ce problème peut se produire avec certaines cartouches homebrew. Assurez-vous que le jeu est jouable, soit en le testant sur une console d'origine, soit dans l'application Playback.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="233" />
         <source>Written game data integrity check failed</source>
-        <translation type="unfinished">Le contrôle de l'intégrité des données du jeu écrit a échoué</translation>
+        <translation>La vérification de l'intégrité des données du jeu écrit a échoué</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="233" />
         <source>Read data does not match written data.</source>
-        <translation type="unfinished">Les données lues ne correspondent pas aux données écrites.</translation>
+        <translation>Les données lues ne correspondent pas aux données écrites.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="340" />
         <source>Write save failed</source>
-        <translation type="unfinished">Échec de la sauvegarde en écriture</translation>
+        <translation>L'écriture de la sauvegarde a échoué</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="340" />
         <source>Failed to send write save command to device.</source>
-        <translation type="unfinished">Échec de l'envoi de la commande de sauvegarde en écriture à l'appareil.</translation>
+        <translation>Échec de l'envoi de l'écriture de la sauvegarde à l'appareil.</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="371" />
         <source>Save Data Integrity Check Failed!</source>
-        <translation type="unfinished">Échec du contrôle de l'intégrité des données !</translation>
+        <translation>La vérification de l'intégrité des données de sauvegarde a échoué !</translation>
     </message>
     <message>
         <location filename="../src/DeviceHardwareOperations.cpp" line="372" />
         <source>The save data written to the cartridge does not match the data read back. Please clean the cartridge pins and try again to ensure consistency.</source>
-        <translation type="unfinished">Les données de sauvegarde écrites dans la cartouche ne correspondent pas aux données lues. Veuillez nettoyer les broches de la cartouche et réessayer pour garantir la cohérence.</translation>
+        <translation>Les données de sauvegarde écrites dans la cartouche ne correspondent pas aux données relues. Veuillez nettoyer les broches de la cartouche et réessayer pour assurer l'authenticité des données.</translation>
     </message>
 </context>
 <context>
@@ -236,7 +236,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceSettingsScreen.h" line="79" />
         <source>Choose one of the options below to set the status of your device’s LED light. Select ‘Static’ to keep the light on or ‘Dark’ to shut it off. Pulse and Strobe coming soon.</source>
-        <translation>Choisissez l'une des options ci-dessous pour définir l'état de la lumière LED de votre appareil. Sélectionnez "Statique" pour que la lumière reste allumée ou "Sombre" pour l'éteindre. Les options "Impulsion" et "Stroboscope" seront bientôt disponibles.</translation>
+        <translation>Choisissez l'une des options ci-dessous pour changer l'état de la lumière LED de votre appareil. Sélectionnez « Statique » pour que la lumière reste allumée ou « Sombre » pour l'éteindre. Les options « Pulsation » et « Stroboscopique » seront bientôt disponibles.</translation>
     </message>
 </context>
 <context>
@@ -244,7 +244,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceSharedMemory.cpp" line="16" />
         <source>Shared Memory Error</source>
-        <translation type="unfinished">Erreur de mémoire partagée</translation>
+        <translation>Erreur de mémoire partagée</translation>
     </message>
 </context>
 <context>
@@ -252,7 +252,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceSwitcherDropdown.h" line="78" />
         <source>Expand your collection on epilogue.co</source>
-        <translation type="unfinished">Développez votre collection sur epilogue.co</translation>
+        <translation>Agrandissez votre collection sur epilogue.co</translation>
     </message>
 </context>
 <context>
@@ -260,7 +260,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/DeviceSwitcherDropdown.cpp" line="194" />
         <source>View more</source>
-        <translation type="unfinished">Voir plus</translation>
+        <translation>Voir plus</translation>
     </message>
 </context>
 <context>
@@ -268,22 +268,22 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/Emulator.cpp" line="265" />
         <source>Failed to load game!</source>
-        <translation type="unfinished">Échec du chargement du jeu !</translation>
+        <translation>Échec du chargement du jeu !</translation>
     </message>
     <message>
         <location filename="../src/Emulator.cpp" line="266" />
         <source>Unable to launch the game, please make sure that the cartridge is clean.</source>
-        <translation type="unfinished">Impossible de lancer le jeu, assurez-vous que la cartouche est propre.</translation>
+        <translation>Le jeu n'a pas pu être démarré : assurez-vous que la cartouche est propre.</translation>
     </message>
     <message>
         <location filename="../src/Emulator.cpp" line="272" />
         <source>Failed to load save data!</source>
-        <translation type="unfinished">Échec du chargement des données de sauvegarde !</translation>
+        <translation>Échec du chargement des données de sauvegarde !</translation>
     </message>
     <message>
         <location filename="../src/Emulator.cpp" line="272" />
         <source>The core failed to load the save data.</source>
-        <translation type="unfinished">Le noyau n'a pas réussi à charger les données de sauvegarde.</translation>
+        <translation>Le cœur n'a pas réussi à charger les données de sauvegarde.</translation>
     </message>
 </context>
 <context>
@@ -293,7 +293,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
         <location filename="../src/EmulatorSettingsScreen.h" line="189" />
         <location filename="../src/EmulatorSettingsScreen.h" line="205" />
         <source>enabled</source>
-        <translation>activée</translation>
+        <translation>activé</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="174" />
@@ -310,7 +310,7 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="139" />
         <source>A fast-forward speed higher than 2x can cause unexpected bugs in combination with the 'Autosave to cartridge' feature. You will need to disable and enable it by clicking the fast-forward button.</source>
-        <translation>Une vitesse d'avance rapide supérieure à 2x peut provoquer des bogues inattendus en combinaison avec la fonction "Autosave to cartridge". Vous devrez la désactiver et l'activer en cliquant sur le bouton d'avance rapide.</translation>
+        <translation>Une avance rapide supérieure à 2x peut provoquer des bugs inattendus en combinaison avec la fonction « Sauvegarder automatiquement sur la cartouche ». Vous devrez désactiver et activer l'avance rapide en appuyant sur le bouton d'avance rapide en jouant.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="164" />
@@ -320,27 +320,27 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="166" />
         <source>Enables high-fidelity mode, making audio and video run at rates close to what you would encounter on the original hardware. This will increase CPU usage, disable it if you notice low framerates.</source>
-        <translation>Active le mode haute fidélité, ce qui permet de faire fonctionner l'audio et la vidéo à des taux proches de ceux que vous rencontreriez sur le matériel d'origine. Cela augmentera l'utilisation du processeur, désactivez-le si vous remarquez des taux d'images faibles.</translation>
+        <translation>Active le mode haute fidélité, permettant de faire fonctionner l'audio et la vidéo à des taux proches de ceux que vous rencontreriez sur la console d'origine. Cela augmentera l'utilisation du processeur, donc désactivez cette option si vous remarquez des taux d'images faibles.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="182" />
         <source>Gamepad rumble</source>
-        <translation>Grondement de la manette de jeu</translation>
+        <translation>Vibration de la manette</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="184" />
         <source>Enable rumble support for games that support it, for more compatibility make sure you also enable Game Boy Player Rumble.</source>
-        <translation>Activez le support rumble pour les jeux qui le supportent. Pour plus de compatibilité, assurez-vous d'activer également le Game Boy Player Rumble.</translation>
+        <translation>Activez les vibrations pour les jeux compatibles. Pour fonctionner avec le plus de jeux compatibles, assurez-vous d'activer également la Vibration Game Boy Player.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="198" />
         <source>In-game save verifications</source>
-        <translation type="unfinished">Vérifications des sauvegardes en jeu</translation>
+        <translation>Vérifications des sauvegardes en jeu</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="200" />
         <source>Enable in-game integrity checks for save data. This feature is still in beta and may not work with all games.</source>
-        <translation type="unfinished">Activer les contrôles d'intégrité dans le jeu pour les données de sauvegarde. Cette fonctionnalité est encore en version bêta et peut ne pas fonctionner avec tous les jeux.</translation>
+        <translation>Activer les vérifications d'intégrité en jeu pour les données de sauvegarde. Cette fonctionnalité est encore en version bêta et peut ne pas fonctionner avec tous les jeux.</translation>
     </message>
 </context>
 <context>
@@ -348,12 +348,12 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
     <message>
         <location filename="../src/UIComponents.cpp" line="94" />
         <source>Warning! Do not disconnect your device.</source>
-        <translation type="unfinished">Avertissement ! Ne déconnectez pas votre appareil.</translation>
+        <translation>Attention ! Ne déconnectez pas votre appareil.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="96" />
         <source>Please DO NOT disconnect or turn off your device during the update process. The LED will turn off during the update. Interruption will lead to your device becoming unusable and void warranty. By agreeing to this message box you confirm your understanding of these instructions.</source>
-        <translation type="unfinished">Veuillez NE PAS déconnecter ou éteindre votre appareil pendant le processus de mise à jour. Le voyant s'éteint pendant la mise à jour. Toute interruption rendra votre appareil inutilisable et annulera la garantie. En acceptant cette boîte de message, vous confirmez votre compréhension de ces instructions.</translation>
+        <translation>Veuillez NE PAS déconnecter ou éteindre votre appareil pendant la mise à jour. La LED s'éteindra pendant la mise à jour. Toute interruption rendra votre appareil inutilisable et annulera la garantie. En acceptant cette boîte de message, vous confirmez votre compréhension de ces instructions.</translation>
     </message>
 </context>
 <context>
@@ -367,8 +367,8 @@ Ne retirez pas la cartouche pendant qu'une opération est en cours.</translation
         <location filename="../src/FirmwareUpdateWindow.h" line="22" />
         <source>This may take up to a minute,
 please do not disconnect the device.</source>
-        <translation>Cela peut prendre jusqu'à une minute,
-ne déconnectez pas l'appareil.</translation>
+        <translation>Cela peut prendre une minute,
+veuillez ne pas déconnectez l'appareil.</translation>
     </message>
     <message>
         <location filename="../src/FirmwareUpdateWindow.h" line="24" />
@@ -382,37 +382,37 @@ ne déconnectez pas l'appareil.</translation>
         <location filename="../src/InputBindingsScreen.cpp" line="17" />
         <location filename="../src/InputBindingsScreen.h" line="69" />
         <source>Rebind keys</source>
-        <translation>Clés Rebind</translation>
+        <translation>Configurer les touches</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.cpp" line="29" />
         <source>Need help?</source>
-        <translation type="unfinished">Besoin d'aide ?</translation>
+        <translation>Besoin d'aide ?</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.h" line="61" />
         <source>Controls Settings</source>
-        <translation type="unfinished">Réglages des contrôles</translation>
+        <translation>Configuration des touches</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.h" line="63" />
         <source>The Playback software comes with pre-configured bindings for most gamepads. Try pressing buttons on your controller or keyboard to test them.</source>
-        <translation type="unfinished">Le logiciel Playback est livré avec des liaisons préconfigurées pour la plupart des manettes de jeu. Essayez d'appuyer sur les boutons de votre manette ou de votre clavier pour les tester.</translation>
+        <translation>Le logiciel Playback contient des configurations par défaut pour la plupart des manettes de jeu. Essayez d'appuyer sur les boutons de votre manette ou sur les touches de votre clavier pour les tester.</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.h" line="66" />
         <source>No gamepads connected.</source>
-        <translation>Aucune manette de jeu n'est connectée.</translation>
+        <translation>Aucune manette n'est connectée.</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.h" line="67" />
         <source>Select a gamepad</source>
-        <translation>Sélectionner une manette de jeu</translation>
+        <translation>Sélectionnez une manette</translation>
     </message>
     <message>
         <location filename="../src/InputBindingsScreen.h" line="70" />
         <source>Cancel rebind</source>
-        <translation>Annuler le rebind</translation>
+        <translation>Annuler le remappage</translation>
     </message>
 </context>
 <context>
@@ -428,7 +428,7 @@ ne déconnectez pas l'appareil.</translation>
 
 You can try cleaning then re-inserting the cartridge into the device.
 </source>
-        <translation>Nous n'avons pas pu confirmer l'intégrité de cette cartouche, souhaitez-vous toujours continuer ? Il se peut que le jeu ne fonctionne pas ou ne soit pas sauvegardé correctement.
+        <translation>Nous n'avons pas pu confirmer l'intégrité des données de cette cartouche, souhaitez-vous quand même continuer ? Il se peut que le jeu ne fonctionne pas ou ne sauvegarde pas correctement.
 
 Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil.
 </translation>
@@ -439,17 +439,17 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="83" />
         <source>Permission denied. Unable to open device.</source>
-        <translation>Permission refusée. Impossible d'ouvrir le périphérique.</translation>
+        <translation>Permission refusée. Impossible d'ouvrir l'appareil.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="85" />
         <source>Please make sure you configure your Linux system to allow unprivileged access to serial ports.</source>
-        <translation>Veillez à configurer votre système Linux de manière à autoriser l'accès non privilégié aux ports série.</translation>
+        <translation>Veuillez configurer votre système Linux afin d'autoriser l'accès non privilégié aux ports série.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="86" />
         <source>Follow this</source>
-        <translation>Suivez ce lien</translation>
+        <translation>Suivez ce</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="87" />
@@ -459,7 +459,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="87" />
         <source>to configure your Operator device.</source>
-        <translation>pour configurer l'appareil de l'opérateur.</translation>
+        <translation>pour configurer l'Operator.</translation>
     </message>
 </context>
 <context>
@@ -472,7 +472,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="65" />
         <source>Your Operator device did not manage to read your cartridge properly. Please make sure that the cartridge is clean and try again.</source>
-        <translation type="unfinished">Votre opérateur n'a pas réussi à lire correctement votre cartouche. Assurez-vous que la cartouche est propre et réessayez.</translation>
+        <translation>Votre appareil Operator n'a pas réussi à lire correctement votre cartouche. Assurez-vous que la cartouche est propre et réessayez.</translation>
     </message>
 </context>
 <context>
@@ -480,7 +480,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/ManagePage.cpp" line="9" />
         <source>START</source>
-        <translation>START</translation>
+        <translation>DÉMARRER</translation>
     </message>
     <message>
         <location filename="../src/ManagePage.cpp" line="18" />
@@ -495,7 +495,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/ManagePage.cpp" line="97" />
         <source>[no checksum available]</source>
-        <translation type="unfinished">[pas de somme de contrôle disponible]</translation>
+        <translation>[somme de contrôle indisponible]</translation>
     </message>
     <message>
         <location filename="../src/ManagePage.h" line="57" />
@@ -505,7 +505,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/ManagePage.h" line="58" />
         <source>Game Data Checksum</source>
-        <translation>Somme de contrôle des données du jeu</translation>
+        <translation>Somme de contrôle des données de jeu</translation>
     </message>
 </context>
 <context>
@@ -518,7 +518,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/ManagePageOperation.cpp" line="50" />
         <source>STOP</source>
-        <translation type="unfinished">STOP</translation>
+        <translation>STOP</translation>
     </message>
     <message>
         <location filename="../src/ManagePageOperation.cpp" line="185" />
@@ -529,7 +529,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/ManagePageOperation.cpp" line="311" />
         <source>START</source>
-        <translation type="unfinished">START</translation>
+        <translation>DÉMARRER</translation>
     </message>
 </context>
 <context>
@@ -542,7 +542,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/UIComponents.cpp" line="76" />
         <source>It looks like there is another instance of the software running on this computer. Closing this instance.</source>
-        <translation type="unfinished">Il semble qu'une autre instance du logiciel soit en cours d'exécution sur cet ordinateur. Fermer cette instance.</translation>
+        <translation>Il semble qu'une autre instance du logiciel soit en cours d'exécution sur cet ordinateur. Veuillez fermer cette instance.</translation>
     </message>
 </context>
 <context>
@@ -550,12 +550,12 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/Navbar.h" line="149" />
         <source>Press ESC to exit emulation</source>
-        <translation>Appuyez sur ESC pour quitter l'émulation</translation>
+        <translation>Appuyez sur ÉCHAP pour quitter l'émulation</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="150" />
         <source>Press TAB to exit mouse capture mode</source>
-        <translation type="unfinished">Appuyez sur la touche TAB pour quitter le mode de capture de la souris</translation>
+        <translation>Appuyez sur TAB pour quitter le mode de capture de la souris</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="151" />
@@ -565,7 +565,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/Navbar.h" line="152" />
         <source>Writing game...</source>
-        <translation>Jeu d'écriture...</translation>
+        <translation>Écriture des données de jeu...</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="153" />
@@ -575,7 +575,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/Navbar.h" line="154" />
         <source>Writing save...</source>
-        <translation>L'écriture sauve...</translation>
+        <translation>Écriture de la sauvegarde...</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="155" />
@@ -588,7 +588,7 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/NavbarComponents.cpp" line="88" />
         <source>Nightly</source>
-        <translation>Tous les soirs</translation>
+        <translation>Nightly</translation>
     </message>
     <message>
         <location filename="../src/NavbarComponents.cpp" line="100" />
@@ -611,27 +611,27 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/NavbarLogoDropdown.cpp" line="38" />
         <source>Support</source>
-        <translation>Soutien</translation>
+        <translation>Aide</translation>
     </message>
     <message>
         <location filename="../src/NavbarLogoDropdown.cpp" line="41" />
         <source>Send Feedback</source>
-        <translation>Envoyer un commentaire</translation>
+        <translation>Envoyer des retours</translation>
     </message>
     <message>
         <location filename="../src/NavbarLogoDropdown.cpp" line="44" />
         <source>Report a Bug</source>
-        <translation>Signaler un bogue</translation>
+        <translation>Signaler un bug</translation>
     </message>
     <message>
         <location filename="../src/NavbarLogoDropdown.cpp" line="48" />
         <source>About</source>
-        <translation>A propos de</translation>
+        <translation>À propos de</translation>
     </message>
     <message>
         <location filename="../src/NavbarLogoDropdown.cpp" line="49" />
         <source>Exit</source>
-        <translation>Sortie</translation>
+        <translation>Quitter</translation>
     </message>
 </context>
 <context>
@@ -652,27 +652,27 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/Navbar.h" line="60" />
         <source>Backup Game</source>
-        <translation>Sauvegarder le Jeu</translation>
+        <translation>Télécharger le jeu</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="61" />
         <source>Upload Homebrew</source>
-        <translation>Télécharger le Homebrew</translation>
+        <translation>Téléverser un homebrew</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="62" />
         <source>Backup Save</source>
-        <translation>Copier la Sauvegarde</translation>
+        <translation>Télécharger la sauvegarde</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="63" />
         <source>Upload Save</source>
-        <translation>Télécharger la Sauvegarder</translation>
+        <translation>Téléverser une sauvegarde</translation>
     </message>
     <message>
         <location filename="../src/Navbar.h" line="64" />
         <source>Photo Gallery</source>
-        <translation>Galerie de Photos</translation>
+        <translation>Galerie photo</translation>
     </message>
 </context>
 <context>
@@ -680,46 +680,46 @@ Vous pouvez essayer de nettoyer puis de réinsérer la cartouche dans l'appareil
     <message>
         <location filename="../src/PhotosPage.cpp" line="100" />
         <source>Scaling factor:</source>
-        <translation>Facteur d'échelle :</translation>
+        <translation>Taille :</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="168" />
         <source>Open Directory</source>
-        <translation>Annuaire ouvert</translation>
+        <translation>Sélectionnez un dossier</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="186" />
         <source>Warning, permanent deletion</source>
-        <translation>Avertissement, suppression permanente</translation>
+        <translation>Attention, la suppression est définitive</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="187" />
         <source>This will permanently delete all the pictures on your Game Boy Camera. Are you sure?</source>
-        <translation>Cela supprimera définitivement toutes les photos de votre Game Boy Camera. Vous êtes sûr de vous ?</translation>
+        <translation>Cela supprimera définitivement toutes les photos de votre Game Boy Camera. Êtes-vous sûr ?</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="15" />
         <source>Photo Gallery</source>
-        <translation>Galerie de photos</translation>
+        <translation>Galerie photo</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.h" line="76" />
         <source>Transfer your pics from your Game Boy Camera to your PC in just two clicks. The images are stored as PNGs of 128x112 pixels. You can scale this using the scaling function.
 
 If you'd like to easily remove all the pictures from your camera, without having to manually delete them one by one in the camera software, you can use the delete button below.</source>
-        <translation>Transférez vos photos de votre Game Boy Camera vers votre PC en deux clics. Les images sont stockées sous forme de PNG de 128x112 pixels. Vous pouvez les mettre à l'échelle à l'aide de la fonction de mise à l'échelle.
+        <translation>Transférez vos photos de votre Game Boy Camera vers votre PC en deux clics. Les images sont stockées au format PNG en 128x112 pixels. Vous pouvez ajuster leur taille en sélectionnant le bouton Taille.
 
-Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans avoir à les supprimer manuellement une par une dans le logiciel de la caméra, vous pouvez utiliser le bouton de suppression ci-dessous.</translation>
+Si vous souhaitez supprimer facilement toutes les images de votre caméra sans avoir à les supprimer manuellement une par une dans le logiciel de la caméra, vous pouvez utiliser le bouton de suppression ci-dessous.</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="13" />
         <source>SAVE ALL</source>
-        <translation>SAUVE-QUI-PENSE</translation>
+        <translation>TOUT SAUVEGARDER</translation>
     </message>
     <message>
         <location filename="../src/PhotosPage.cpp" line="14" />
         <source>DELETE ALL</source>
-        <translation>SUPPRIMER TOUT</translation>
+        <translation>TOUT SUPPRIMER</translation>
     </message>
 </context>
 <context>
@@ -731,21 +731,21 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="116" />
         <source>Preferred Language (requires restart)</source>
-        <translation type="unfinished">Langue préférée (nécessite un redémarrage)</translation>
+        <translation>Langue préférée (nécessite un redémarrage)</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="117" />
         <source>Allows you to change the language in which the Playback software is presented. It requires an application restart in order to update the language accross the entire application.</source>
-        <translation type="unfinished">Permet de changer la langue dans laquelle le logiciel de lecture est présenté. Un redémarrage de l'application est nécessaire pour mettre à jour la langue dans l'ensemble de l'application.</translation>
+        <translation>Permet de changer la langue dans laquelle le logiciel Playback est affiché. Un redémarrage de l'application est nécessaire pour mettre à jour la langue dans l'ensemble de l'application.</translation>
     </message>
     <message>
         <source>Autosave to cartridge (beta)</source>
-        <translation type="obsolete">Sauvegarde automatique sur cartouche (beta)</translation>
+        <translation type="obsolete">Sauvegarder automatiquement sur la cartouche (bêta)</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="151" />
         <source>Once you save in-game, or the game modifies the save internally, your Operator device will automatically write the save to the cartridge. This feature is still in development.</source>
-        <translation type="unfinished">Une fois que vous avez sauvegardé dans le jeu, ou que le jeu a modifié la sauvegarde en interne, votre appareil Operator écrira automatiquement la sauvegarde sur la cartouche. Cette fonction est encore en cours de développement.</translation>
+        <translation>Une fois que vous avez sauvegardé en jeu, ou que le jeu a modifié la sauvegarde en interne, votre appareil Operator écrira automatiquement la sauvegarde sur la cartouche. Cette fonction est encore en cours de développement.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="154" />
@@ -756,7 +756,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
         <location filename="../src/PlaybackSettingsScreen.h" line="195" />
         <location filename="../src/PlaybackSettingsScreen.h" line="204" />
         <source>Enabled</source>
-        <translation type="unfinished">Activé</translation>
+        <translation>Activé</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="154" />
@@ -767,102 +767,102 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
         <location filename="../src/PlaybackSettingsScreen.h" line="195" />
         <location filename="../src/PlaybackSettingsScreen.h" line="204" />
         <source>Disabled</source>
-        <translation type="unfinished">Handicapés</translation>
+        <translation>Désactivé</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="159" />
         <source>FPS Counter</source>
-        <translation type="unfinished">Compteur FPS</translation>
+        <translation>Compteur d'IPS</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="160" />
         <source>Displays the current frames per second (FPS) of the game being played.</source>
-        <translation type="unfinished">Affiche le nombre d'images par seconde (FPS) du jeu en cours.</translation>
+        <translation>Affiche le nombre d'images par seconde (IPS) du jeu en cours.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="138" />
         <source>Preferred emulator core</source>
-        <translation type="unfinished">Noyau d'émulateur préféré</translation>
+        <translation>Cœur d'émulateur préféré</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="139" />
         <source>Allows you to select the preferred emulation core for running games. Different cores may offer varying levels of accuracy, performance, or compatibility with specific games. Choose the core that best suits your needs and the game you're playing.</source>
-        <translation type="unfinished">Permet de sélectionner le noyau d'émulation préféré pour l'exécution des jeux. Les différents noyaux peuvent offrir différents niveaux de précision, de performance ou de compatibilité avec des jeux spécifiques. Choisissez le noyau qui correspond le mieux à vos besoins et au jeu auquel vous jouez.</translation>
+        <translation>Permet de sélectionner le cœur d'émulation préféré pour l'exécution des jeux. Les différents cœurs peuvent offrir différents niveaux de précision, de performance ou de compatibilité avec des jeux spécifiques. Choisissez le cœur correspondant au mieux à vos besoins et au jeu auquel vous jouez.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="150" />
         <source>Autosave to cartridge</source>
-        <translation type="unfinished">Sauvegarde automatique dans la cartouche</translation>
+        <translation>Sauvegarder automatiquement sur la cartouche</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="166" />
         <source>RTC data in save file</source>
-        <translation type="unfinished">Données RTC dans le fichier de sauvegarde</translation>
+        <translation>Données HTR dans le fichier de sauvegarde</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="167" />
         <source>When enabled and supported by the game, Playback adds real-time clock (RTC) data to the save file. This ensures accurate preservation of time-based events. Note that this will increase the file size and might make it incompatible with other software.</source>
-        <translation type="unfinished">Lorsqu'elle est activée et prise en charge par le jeu, la lecture ajoute des données d'horloge en temps réel (RTC) au fichier de sauvegarde. Cela permet de préserver avec précision les événements temporels. Notez que cela augmente la taille du fichier et peut le rendre incompatible avec d'autres logiciels.</translation>
+        <translation>Lorsqu'activé et pris en charge par le jeu, Playback ajoute les données de l'horloge temps réel (HTR) au fichier de sauvegarde. Cela permet de conserver fidèlement les événements liés au temps. Notez que cela augmente la taille du fichier et peut le rendre incompatible avec d'autres logiciels.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="175" />
         <source>Verify Save After Writing Process</source>
-        <translation type="unfinished">Vérifier la sauvegarde après le processus d'écriture</translation>
+        <translation>Vérifier la sauvegarde après l'écriture</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="176" />
         <source>Activating this setting prompts Playback to check that the save file remains uncorrupted after being written to the cartridge. It ensures your game progress has been safely stored.</source>
-        <translation type="unfinished">L'activation de ce paramètre invite la lecture à vérifier que le fichier de sauvegarde n'a pas été altéré après avoir été écrit sur la cartouche. Cela permet de s'assurer que la progression du jeu a été sauvegardée en toute sécurité.</translation>
+        <translation>Activer ce paramètre force Playback à vérifier que le fichier de sauvegarde n'a pas été corrompu après avoir été écrit sur la cartouche. Cela permet de s'assurer que les données du jeu ont été sauvegardées en toute sécurité.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="183" />
         <source>Verify Save is Read Properly</source>
-        <translation type="unfinished">Vérifier que la sauvegarde est lue correctement</translation>
+        <translation>Vérifier que la sauvegarde est lue correctement</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="184" />
         <source>When this setting is enabled, Playback reads the save file from the cartridge multiple times and reviews any discrepancies to prevent data corruption.</source>
-        <translation type="unfinished">Lorsque ce paramètre est activé, la lecture lit plusieurs fois le fichier de sauvegarde à partir de la cartouche et examine toute anomalie afin d'éviter la corruption des données.</translation>
+        <translation>Lorsque ce paramètre est activé, l'application lit plusieurs fois la sauvegarde de la cartouche et examine toute anomalie afin d'éviter la corruption des données.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="192" />
         <source>Verify Homebrew File Integrity</source>
-        <translation type="unfinished">Vérifier l'intégrité des fichiers Homebrew</translation>
+        <translation>Vérifier l'intégrité des données du fichier homebrew</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="193" />
         <source>This setting enables Playback to confirm the integrity of a homebrew game after transferring it to the cartridge, making sure there are no issues affecting your work.</source>
-        <translation type="unfinished">Ce paramètre permet à Playback de confirmer l'intégrité d'un jeu homebrew après l'avoir transféré sur la cartouche, afin de s'assurer qu'aucun problème n'affecte votre travail.</translation>
+        <translation>Ce paramètre force Playback à confirmer l'intégrité d'un jeu homebrew après l'avoir transféré sur la cartouche, afin de s'assurer qu'aucun problème n'affecte votre travail.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="200" />
         <source>Enable verbose debug logs (requires restart)</source>
-        <translation type="unfinished">Activer les journaux de débogage (nécessite un redémarrage)</translation>
+        <translation>Activer les journaux de débogage descriptifs (nécessite un redémarrage)</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.h" line="201" />
         <source>When enabled, the Playback software will output more detailed logs to help diagnose issues. This setting is useful for troubleshooting and should be disabled when not needed.</source>
-        <translation type="unfinished">Lorsque cette option est activée, le logiciel de lecture produit des journaux plus détaillés pour aider à diagnostiquer les problèmes. Ce paramètre est utile pour le dépannage et doit être désactivé lorsqu'il n'est pas nécessaire.</translation>
+        <translation>Lorsque cette option est activée, Playback produit des journaux plus détaillés pour aider à diagnostiquer les problèmes. Ce paramètre est utile pour le dépannage et doit être désactivé lorsqu'il n'est pas nécessaire.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="49" />
         <source>General</source>
-        <translation type="unfinished">Général</translation>
+        <translation>Général</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="49" />
         <source>Customize general settings to offer a personalized experience.</source>
-        <translation type="unfinished">Personnaliser les paramètres généraux pour offrir une expérience personnalisée.</translation>
+        <translation>Changez les paramètres globaux pour modifier votre expérience.</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="52" />
         <source>Data</source>
-        <translation type="unfinished">Données</translation>
+        <translation>Données</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="52" />
         <source>Configure how transfers are handled in the Data section of Playback.</source>
-        <translation type="unfinished">Configurez le traitement des transferts dans la section Données de la lecture.</translation>
+        <translation>Modifiez le traitement des transferts dans la section Données de Playback.</translation>
     </message>
 </context>
 <context>
@@ -870,12 +870,12 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="196" />
         <source>Open Log Directory</source>
-        <translation type="unfinished">Répertoire des journaux ouverts</translation>
+        <translation>Ouvrir le dossier des journaux</translation>
     </message>
     <message>
         <location filename="../src/PlaybackSettingsScreen.cpp" line="202" />
         <source>Open Cores Directory</source>
-        <translation type="unfinished">Répertoire des noyaux ouverts</translation>
+        <translation>Ouvrir le dossier des cœurs</translation>
     </message>
 </context>
 <context>
@@ -891,12 +891,12 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
     <message>
         <location filename="../src/AboutWindow.cpp" line="94" />
         <source>Copyright Notices</source>
-        <translation>Avis de droit d'auteur</translation>
+        <translation>Mentions de copyright</translation>
     </message>
     <message>
         <location filename="../src/AboutWindow.cpp" line="95" />
         <source>Software License</source>
-        <translation>Licence de logiciel</translation>
+        <translation>Licence logiciel</translation>
     </message>
     <message>
         <location filename="../src/AboutWindow.cpp" line="154" />
@@ -916,7 +916,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
     <message>
         <location filename="../src/AboutWindow.cpp" line="157" />
         <source>Core Version</source>
-        <translation>Version de base</translation>
+        <translation>Version du cœur</translation>
     </message>
     <message>
         <location filename="../src/CartDetailsWidget.cpp" line="9" />
@@ -926,12 +926,12 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
     <message>
         <location filename="../src/CartDetailsWidget.cpp" line="11" />
         <source>The description of this cartridge can’t be displayed since it’s not in our database. You can use the link below to open a ticket and we’ll add the game info to the database. Please feel free to contact us even if it’s a homebrew game you made if you’d like to have your artwork displayed here.</source>
-        <translation>La description de cette cartouche ne peut être affichée car elle n'est pas dans notre base de données. Vous pouvez utiliser le lien ci-dessous pour ouvrir un ticket et nous ajouterons les informations du jeu à la base de données. N'hésitez pas à nous contacter même s'il s'agit d'un jeu homebrew que vous avez créé si vous souhaitez que votre œuvre soit affichée ici.</translation>
+        <translation>La description de cette cartouche ne peut être affichée car elle n'est pas dans notre base de données. Vous pouvez utiliser le lien ci-dessous pour ouvrir un ticket et nous ajouterons les informations du jeu dans la base de données. N'hésitez pas à nous contacter même s'il s'agit d'un jeu homebrew que vous avez créé si vous souhaitez que votre jaquette soit affichée ici.</translation>
     </message>
     <message>
         <location filename="../src/CartDetailsWidget.cpp" line="18" />
         <source>Submit cartridge information</source>
-        <translation>Soumettre des informations sur les cartouches</translation>
+        <translation>Envoyer des informations sur la cartouche</translation>
     </message>
     <message>
         <location filename="../src/CartDetailsWidget.cpp" line="19" />
@@ -951,12 +951,12 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
     <message>
         <location filename="../src/DeviceSettingsScreen.cpp" line="7" />
         <source>Pulse</source>
-        <translation>Pulse</translation>
+        <translation>Pulsation</translation>
     </message>
     <message>
         <location filename="../src/DeviceSettingsScreen.cpp" line="8" />
         <source>Strobe</source>
-        <translation>Strobe</translation>
+        <translation>Stroboscopique</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.h" line="48" />
@@ -965,7 +965,7 @@ Si vous souhaitez supprimer facilement toutes les images de votre caméra, sans 
 Tip: Our app runs a Data Integrity Test to make sure that you are getting an accurate reproduction of the cartridge’s content.</source>
         <translation>Archivez vos données de jeu en toute sécurité sur votre ordinateur et créez un équivalent numérique de votre collection de jeux. Les fichiers de jeu sont compatibles avec l'émulateur de votre choix.
 
-Astuce : Notre application effectue un test d'intégrité des données pour s'assurer que vous obtenez une reproduction exacte du contenu de la cartouche.</translation>
+Astuce : Notre application effectue une vérification de l'intégrité des données pour s'assurer que vous obtenez une reproduction exacte du contenu de la cartouche.</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.h" line="54" />
@@ -974,16 +974,16 @@ Astuce : Notre application effectue un test d'intégrité des données pour s'as
 Tip: Transfer your homebrew game to a cartridge and play it on original hardware.</source>
         <translation>Remplacez les données de jeu de votre cartouche par un autre fichier. Assurez-vous que le fichier de jeu que vous écrivez est valide en le testant d'abord dans un émulateur externe.
 
-Conseil : transférez votre jeu homebrew sur une cartouche et jouez-y sur le matériel d'origine.</translation>
+Astuce : transférez votre jeu homebrew sur une cartouche et jouez-y sur la console d'origine.</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.h" line="58" />
         <source>Transfer a duplicate of your save data from the cartridge to your computer. You can then back up your save file or edit it with an external program.
 
 Tip: Transfer your save to the computer, replace the battery and transfer it back to the cartridge safely.</source>
-        <translation>Transférez une copie de vos données de sauvegarde de la cartouche vers votre ordinateur. Vous pouvez alors sauvegarder votre fichier de sauvegarde ou le modifier avec un programme externe.
+        <translation>Transférez une copie de vos données de sauvegarde de votre cartouche vers votre ordinateur. Vous pourrez alors sauvegarder votre fichier de sauvegarde ou le modifier avec un programme externe.
 
-Conseil : transférez votre sauvegarde sur l'ordinateur, remplacez la batterie et transférez-la à nouveau sur la cartouche en toute sécurité.</translation>
+Astuce : transférez votre sauvegarde sur l'ordinateur, remplacez la batterie et transférez-la à nouveau sur la cartouche en toute sécurité.</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.h" line="64" />
@@ -992,22 +992,22 @@ Conseil : transférez votre sauvegarde sur l'ordinateur, remplacez la batterie e
 Tip: Use external programs to trigger in-game events or customize gameplay.</source>
         <translation>Transférez une copie de vos données de sauvegarde de votre ordinateur vers la cartouche et reprenez le jeu là où vous l'avez laissé.
 
-Conseil : utilisez des programmes externes pour déclencher des événements dans le jeu ou personnaliser la jouabilité.</translation>
+Astuce : utilisez des programmes externes pour déclencher des événements dans le jeu ou en modifier le gameplay.</translation>
     </message>
     <message>
         <location filename="../src/ErrorMessages.h" line="26" />
         <source>Follow this</source>
-        <translation type="unfinished">Suivez ce lien</translation>
+        <translation>Suivez ce</translation>
     </message>
     <message>
         <location filename="../src/ErrorMessages.h" line="30" />
         <source>tutorial</source>
-        <translation type="unfinished">tutoriel</translation>
+        <translation>tutoriel</translation>
     </message>
     <message>
         <location filename="../src/ErrorMessages.h" line="30" />
         <source>for cleaning your cartridge pins.</source>
-        <translation type="unfinished">pour nettoyer les broches de votre cartouche.</translation>
+        <translation>pour nettoyer les broches de votre cartouche.</translation>
     </message>
 </context>
 <context>
@@ -1015,12 +1015,12 @@ Conseil : utilisez des programmes externes pour déclencher des événements dan
     <message>
         <location filename="../src/UIComponents.cpp" line="26" />
         <source>You are about to quit.</source>
-        <translation>Vous êtes sur le point de démissionner.</translation>
+        <translation>Vous êtes sur le point de quitter.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="27" />
         <source>Are you sure you want to exit?</source>
-        <translation>Êtes-vous sûr de vouloir sortir ?</translation>
+        <translation>Êtes-vous sûr de vouloir quitter ?</translation>
     </message>
 </context>
 <context>
@@ -1028,7 +1028,7 @@ Conseil : utilisez des programmes externes pour déclencher des événements dan
     <message>
         <location filename="../src/UIComponents.cpp" line="52" />
         <source>Mismatched save size</source>
-        <translation>Taille d'enregistrement inadaptée</translation>
+        <translation>Taille de la sauvegarde inadéquate</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="53" />
@@ -1038,11 +1038,11 @@ You can read more about this issue here. Backups of the original save on the car
 
 Would you like to proceed?
 </source>
-        <translation>Le noyau de l'émulateur signale actuellement une taille de sauvegarde différente de celle que nous avons détectée sur la cartouche.
+        <translation>Le cœur de l'émulateur signale actuellement une taille de sauvegarde différente de celle que nous avons détectée sur la cartouche.
 
-Vous pouvez en savoir plus sur ce problème ici. Des sauvegardes de la sauvegarde originale sur la cartouche sont effectuées dans le coffre-fort, mais la procédure peut créer des sauvegardes inutilisables.
+Vous pouvez en savoir plus sur ce problème ici. Des copies de la sauvegarde originale sur la cartouche sont effectuées dans le coffre-fort, mais continuer pourrait créer des sauvegardes inutilisables.
 
-Souhaitez-vous continuer ?
+Souhaitez-vous tout de même continuer ?
 </translation>
     </message>
 </context>
@@ -1057,7 +1057,7 @@ Souhaitez-vous continuer ?
         <location filename="../src/SearchWindow.h" line="24" />
         <source>Looking for your Operator device.
 Please make sure it's connected.</source>
-        <translation>Vous recherchez votre dispositif d'opérateur.
+        <translation>Recherche de l'appareil Operator.
 Assurez-vous qu'il est connecté.</translation>
     </message>
     <message>
@@ -1071,22 +1071,22 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="130" />
         <source>System</source>
-        <translation type="unfinished">Système</translation>
+        <translation>Système</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="130" />
         <source>Configure base hardware selection.</source>
-        <translation type="unfinished">Configurer la sélection du matériel de base.</translation>
+        <translation>Modifiez les paramètres de base de la console.</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="131" />
         <source>Input &amp; Auxiliary Devices</source>
-        <translation type="unfinished">Dispositifs d'entrée et auxiliaires</translation>
+        <translation>Dispositifs d'entrée et auxiliaires</translation>
     </message>
     <message>
         <location filename="../src/EmulatorSettingsScreen.h" line="132" />
         <source>Configure controller and controller rumble settings.</source>
-        <translation type="unfinished">Configurer les paramètres du contrôleur et du grondement du contrôleur.</translation>
+        <translation>Modifiez les paramètres liés à la manette et aux vibrations.</translation>
     </message>
 </context>
 <context>
@@ -1109,17 +1109,17 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/SettingsWindow.h" line="77" />
         <source>Controls Settings</source>
-        <translation type="unfinished">Réglages des contrôles</translation>
+        <translation>Paramètres des touches</translation>
     </message>
     <message>
         <location filename="../src/SettingsWindow.h" line="79" />
         <source>Cheat Codes</source>
-        <translation type="unfinished">Codes de triche</translation>
+        <translation>Codes de triche</translation>
     </message>
     <message>
         <location filename="../src/SettingsWindow.h" line="82" />
         <source>Playback Settings</source>
-        <translation type="unfinished">Réglages de lecture</translation>
+        <translation>Paramètres de Playback</translation>
     </message>
 </context>
 <context>
@@ -1132,7 +1132,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/SettingsWindowUIComponents.cpp" line="31" />
         <source>Restore defaults</source>
-        <translation>Rétablir les valeurs par défaut</translation>
+        <translation>Réinitialiser options</translation>
     </message>
 </context>
 <context>
@@ -1140,13 +1140,13 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/StartControllerWidget.cpp" line="138" />
         <source>STOP</source>
-        <translation type="unfinished">STOP</translation>
+        <translation>STOP</translation>
     </message>
     <message>
         <location filename="../src/StartControllerWidget.cpp" line="138" />
         <location filename="../src/StartControllerWidget.cpp" line="145" />
         <source>START</source>
-        <translation type="unfinished">START</translation>
+        <translation>DÉMARRER</translation>
     </message>
 </context>
 <context>
@@ -1154,7 +1154,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/StartControllerWidget.cpp" line="8" />
         <source>START</source>
-        <translation>START</translation>
+        <translation>DÉMARRER</translation>
     </message>
     <message>
         <location filename="../src/StartControllerWidget.cpp" line="9" />
@@ -1164,7 +1164,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/StartControllerWidget.cpp" line="12" />
         <source>Access the Vault for this game. The vault contains auto-saves created while playing the game.</source>
-        <translation>Accédez au coffre-fort de ce jeu. Le coffre-fort contient les sauvegardes automatiques créées pendant le jeu.</translation>
+        <translation>Accédez au coffre-fort de ce jeu. Le coffre-fort contient les sauvegardes automatiques créées en jouant au jeu avec Playback.</translation>
     </message>
 </context>
 <context>
@@ -1172,7 +1172,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/UIComponents.cpp" line="34" />
         <source>You are about to quit.</source>
-        <translation>Vous êtes sur le point de démissionner.</translation>
+        <translation>Vous êtes sur le point de quitter.</translation>
     </message>
     <message>
         <location filename="../src/UIComponents.cpp" line="35" />
@@ -1187,22 +1187,22 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/ViewRouter.cpp" line="11" />
         <source>Backup Game</source>
-        <translation>Jeu de sauvegarde</translation>
+        <translation>Télécharger le jeu</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.cpp" line="13" />
         <source>Upload Homebrew</source>
-        <translation>Télécharger le Homebrew</translation>
+        <translation>Téléverser un homebrew</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.cpp" line="15" />
         <source>Backup Save</source>
-        <translation>Sauvegarde Sauvegarde</translation>
+        <translation>Télécharger la sauvegarde</translation>
     </message>
     <message>
         <location filename="../src/ViewRouter.cpp" line="17" />
         <source>Upload Save</source>
-        <translation>Télécharger la Sauvegarder</translation>
+        <translation>Téléverser une sauvegarde</translation>
     </message>
 </context>
 <context>
@@ -1225,7 +1225,7 @@ Assurez-vous qu'il est connecté.</translation>
     <message>
         <location filename="../src/Window.cpp" line="144" />
         <source>Start</source>
-        <translation>Démarrage</translation>
+        <translation>Démarrer</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Wanted to see if I could help with the French translation, and I remembered hearing that the French translation was wobbly (reason: DeepL), so I checked it and indeed, lot of things to correct, so I decided to give it a hand.
All of the editing was done using a notepad, so it's possible syntax errors slided in, though I've tried my best to make it as accurate as possible without issues.

I've removed the unfinished tag for each entry, checking if the entry was accurate or not, and if not, the text was also accordingly edited. I've also edited other lines, either when it was inaccurate, or when it could be better worded.


Since editing the file conflicts with #12 , and that I had no idea if it were to be applied or not, so I did a first commit solely based on how the repo is at the moment, and then applied a final commit to bring all of the changes from #12 here. At such, if the changes from #12 are to be applied, the final commit can directly be used, if not, the branch can be reverted to its first commit which only includes the translation changes tied to the repo.

Tied to the translation, I've noticed that the Game Boy Player Rumble lines seem to be translated on the app but don't seem to be present here, I wonder where they are located.

The readme was left untouched: I'm not sure if you plan to edit it too, and I don't really know if this level of edits would be considered as Human or DeepL.

Some translation notes can be seen in the first commit, though they only cover things where I had things to say, whether it being for info, being something that could be discussed, or for being "here's a mistranslation from DeepL, have fun laughing at it".

If you have any question or things to ask me to do on this translation, let me know!